### PR TITLE
feat(sharing): add ComeToCode 2026 and rework upcoming as itinerary

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -248,7 +248,7 @@ const HOBBIES = [
   {
     label: "JuJutsu",
     icon: IconKarate,
-    context: "Hontai Yōshin-ryū. White belt — still figuring out how to fall correctly.",
+    context: "Hontai Yōshin-ryū. Yellow belt — orange is the next milestone.",
     href: null,
   },
   {

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -213,12 +213,12 @@ export default function NowPage() {
             },
             {
               label: "JuJutsu",
-              context: "Hontai Yōshin-ryū. White belt. First kata for yellow belt exam.",
+              context: "Hontai Yōshin-ryū. Yellow belt earned — now training for orange next year.",
             },
             {
-              label: "Crimson Desert",
+              label: "Gaming",
               context:
-                "A vast, living open world pulling me in hard. Clunky controls and thin characters, but the immersion wins.",
+                "Lost in Crimson Desert's open world, with Pokémon Pokopia as the cozy palate cleanser.",
             },
           ].map((item, i) => (
             <ScrollReveal key={item.label} delay={i * 60}>

--- a/src/components/sections/TalksList.tsx
+++ b/src/components/sections/TalksList.tsx
@@ -15,6 +15,21 @@ function formatDate(dateStr: string): string {
   });
 }
 
+// Coarse, drift-tolerant proximity hint for the next upcoming stop.
+function formatRelative(dateStr: string, today: Date): string {
+  const days = Math.round((new Date(dateStr).getTime() - today.getTime()) / 86_400_000);
+  if (days <= 7) return "this week";
+  if (days <= 21) return "in a few weeks";
+  const months = Math.max(1, Math.round(days / 30));
+  return months === 1 ? "next month" : `in ${months} months`;
+}
+
+interface Timeline {
+  isFirst: boolean;
+  isLast: boolean;
+  relative?: string;
+}
+
 interface TalksListProps {
   talks: Talk[];
 }
@@ -28,7 +43,17 @@ function buildEngageCommand(talk: Talk): string {
   return `engage${flags.length > 0 ? ` ${flags.join(" ")}` : ""}`;
 }
 
-function TalkCard({ talk, index, activeTag }: { talk: Talk; index: number; activeTag?: string }) {
+function TalkCard({
+  talk,
+  index,
+  activeTag,
+  timeline,
+}: {
+  talk: Talk;
+  index: number;
+  activeTag?: string;
+  timeline?: Timeline;
+}) {
   const { session } = talk;
   const hasMedia = !!(session?.slides || session?.video);
   const displayDate = talk.eventDateRange ?? formatDate(talk.date);
@@ -36,8 +61,39 @@ function TalkCard({ talk, index, activeTag }: { talk: Talk; index: number; activ
 
   return (
     <ScrollReveal delay={index * 60}>
-      <li id={talk.slug} className="scroll-mt-20">
+      <li id={talk.slug} className={`scroll-mt-20 ${timeline ? "relative pl-8" : ""}`}>
+        {timeline && (
+          <>
+            {/* Itinerary spine: a continuous line bounded by the first and last nodes */}
+            {!timeline.isFirst && (
+              <span aria-hidden className="absolute left-[5px] top-0 h-6 w-px bg-border" />
+            )}
+            {!timeline.isLast && (
+              <span aria-hidden className="absolute left-[5px] top-6 bottom-0 w-px bg-border" />
+            )}
+            {/* Stop node: filled accent for the next stop, hollow for the rest */}
+            <span
+              aria-hidden
+              className={`absolute left-[1px] top-5 z-10 h-[9px] w-[9px] rounded-[1px] ${
+                timeline.isFirst ? "bg-accent" : "border border-border-mid bg-bg"
+              }`}
+            />
+          </>
+        )}
         <div className="py-6 flex flex-col gap-4">
+          {/* Next-stop eyebrow */}
+          {timeline?.isFirst && (
+            <div className="flex items-center gap-2 font-mono text-[11px]">
+              <span className="text-accent">❯ next</span>
+              {timeline.relative && (
+                <>
+                  <span className="text-text-3">·</span>
+                  <span className="text-text-2">{timeline.relative}</span>
+                </>
+              )}
+            </div>
+          )}
+
           {/* Top row: date · location */}
           <div className="flex flex-wrap items-center gap-2 sm:gap-4">
             <span className="font-mono text-[11px] text-text-3">{displayDate}</span>
@@ -46,12 +102,12 @@ function TalkCard({ talk, index, activeTag }: { talk: Talk; index: number; activ
           </div>
 
           {/* Path: ./event / session title */}
-          <h2 className="font-mono text-[16px] sm:text-[18px] leading-snug">
+          <h3 className="font-mono text-[16px] sm:text-[18px] leading-snug">
             <span className="text-accent">./</span>
             <span className="text-text-2">{talk.event}</span>
             <span className="text-text-3"> / </span>
             {session && <span className="text-text-1 font-semibold">{session.title}</span>}
-          </h2>
+          </h3>
 
           {/* Event type badge */}
           <div className="flex flex-wrap items-center gap-3">
@@ -149,7 +205,10 @@ export function TalksList({ talks }: TalksListProps) {
     ? talks.filter((t) => t.tags.map((tag) => tag.toLowerCase()).includes(activeTag.toLowerCase()))
     : talks;
 
-  const upcoming = filtered.filter((t) => new Date(t.date) >= today);
+  // Upcoming reads as an itinerary: soonest stop first. Past stays newest-first.
+  const upcoming = filtered
+    .filter((t) => new Date(t.date) >= today)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   const past = filtered.filter((t) => new Date(t.date) < today);
 
   const byYear = past.reduce<Record<string, typeof past>>((acc, talk) => {
@@ -160,13 +219,9 @@ export function TalksList({ talks }: TalksListProps) {
   const years = Object.keys(byYear).sort((a, b) => Number(b) - Number(a));
 
   return (
-    <>
-      <ScrollReveal>
-        <SectionHeader title="Engagements" className="border-t border-border pt-10" />
-      </ScrollReveal>
-
+    <div className="border-t border-border pt-10">
       {activeTag && (
-        <div className="flex items-center gap-2 font-mono text-[12px] mb-6">
+        <div className="flex items-center gap-2 font-mono text-[12px] mb-10">
           <span className="text-accent">❯</span>
           <span className="text-text-3">grep --tag</span>
           <span className="text-accent">#{activeTag.toLowerCase()}</span>
@@ -180,42 +235,61 @@ export function TalksList({ talks }: TalksListProps) {
         </div>
       )}
 
-      <div className="flex flex-col gap-12">
+      <div className="flex flex-col gap-16">
         {upcoming.length > 0 && (
           <section>
             <ScrollReveal>
-              <SectionHeader title="Upcoming" variant="subsection" />
+              <SectionHeader title="Upcoming Engagements" />
+              <p className="font-sans text-[13px] text-text-3 -mt-8 mb-8">
+                Where you can catch me next — soonest first.
+              </p>
             </ScrollReveal>
-            <ul className="flex flex-col divide-y divide-border">
+            <ul className="flex flex-col">
               {upcoming.map((talk, i) => (
-                <TalkCard key={talk.slug} talk={talk} index={i} activeTag={activeTag} />
+                <TalkCard
+                  key={talk.slug}
+                  talk={talk}
+                  index={i}
+                  activeTag={activeTag}
+                  timeline={{
+                    isFirst: i === 0,
+                    isLast: i === upcoming.length - 1,
+                    relative: i === 0 ? formatRelative(talk.date, today) : undefined,
+                  }}
+                />
               ))}
             </ul>
           </section>
         )}
 
         {past.length > 0 && (
-          <>
-            {upcoming.length > 0 && (
-              <ScrollReveal>
-                <SectionHeader title="Past" variant="subsection" />
-              </ScrollReveal>
-            )}
-            {years.map((year) => (
-              <section key={year}>
-                <ScrollReveal>
-                  <SectionHeader title={year} variant="subsection" />
-                </ScrollReveal>
-                <ul className="flex flex-col divide-y divide-border">
-                  {byYear[year].map((talk, i) => (
-                    <TalkCard key={talk.slug} talk={talk} index={i} activeTag={activeTag} />
-                  ))}
-                </ul>
-              </section>
-            ))}
-          </>
+          <section>
+            <ScrollReveal>
+              <SectionHeader title="Past Engagements" />
+            </ScrollReveal>
+            <div className="flex flex-col gap-10">
+              {years.map((year) => (
+                <div key={year}>
+                  <ScrollReveal>
+                    {/* T3 group divider — year grouping, subordinate to the Past section */}
+                    <div className="flex items-center gap-3 mb-4">
+                      <span className="font-mono text-[11px] text-text-3 tracking-[0.08em]">
+                        {year}
+                      </span>
+                      <span aria-hidden className="h-px flex-1 bg-border" />
+                    </div>
+                  </ScrollReveal>
+                  <ul className="flex flex-col divide-y divide-border">
+                    {byYear[year].map((talk, i) => (
+                      <TalkCard key={talk.slug} talk={talk} index={i} activeTag={activeTag} />
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </section>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/content/talks.json
+++ b/src/content/talks.json
@@ -13,6 +13,19 @@
     }
   },
   {
+    "slug": "cometocode-2026",
+    "event": "ComeToCode 2026",
+    "type": "Conference",
+    "date": "2026-09-26",
+    "eventDateRange": "Sep 26–27",
+    "location": "Pignola, Italy",
+    "tags": ["Security", "AI"],
+    "session": {
+      "title": "Il security engineer che già AI",
+      "format": "Talk"
+    }
+  },
+  {
     "slug": "open-source-day-2026",
     "event": "Open Source Day 2026",
     "type": "Conference",


### PR DESCRIPTION
- Add ComeToCode 2026 talk (Pignola, Sep 26–27)
- Rework engagements: upcoming sorted soonest-first with an itinerary spine + next marker, past stays an archive grouped by year
- Fix heading hierarchy (talk titles h2 → h3, promote Upcoming/Past to section tier, year groups as dividers)
- now/about: JiuJitsu yellow belt (aiming for orange), merge Crimson Desert + Pokémon Pokopia into a single Gaming card