### PR TITLE
Newsletter: Kit free-tier verification spike (#71)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -16,3 +16,13 @@ TURNSTILE_SECRET_KEY=
 # Website ID from https://cloud.umami.is → Settings → Websites → Edit.
 # When empty, no analytics script is rendered.
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+
+# Kit (formerly ConvertKit) — newsletter delivery (free "Newsletter" plan)
+# SERVER-SIDE ONLY. Never prefix with NEXT_PUBLIC_ — the API key must never reach
+# the client bundle. Used by the subscribe server action and the digest skill.
+# v4 API key, sent as the X-Kit-Api-Key header. Create at Kit → Settings → Developer.
+KIT_API_KEY=
+# Id of the double-opt-in-enabled Kit Form subscribers are routed through, if the
+# direct POST /v4/subscribers path does not trigger Kit's confirmation email.
+# See docs/research/kit-api-verification-spike.md for which path the live test picked.
+KIT_FORM_ID=

--- a/docs/adr/0002-newsletter-hybrid-kit-in-repo-content.md
+++ b/docs/adr/0002-newsletter-hybrid-kit-in-repo-content.md
@@ -1,0 +1,40 @@
+# ADR-0002: Monthly newsletter — hybrid model with Kit for delivery, content owned in-repo
+
+- **Status:** Accepted
+- **Date:** 2026-07-22
+- **Research:** [Free-tier newsletter/email tool comparison](../research/newsletter-free-tier-comparison.md) (all numbers and API surfaces verified against primary sources on 2026-07-22)
+
+## Context
+
+The site has no newsletter. The goal is a **monthly digest** — a harvest of what was published (blog posts, talks, projects/OSS) plus a short personal intro and an "upcoming talks" section — with an on-site archive of past issues. Hard constraints: **zero cost at this stage** (the list may be tiny for a long time, so any recurring fee is waste), the tool must be **code-manageable and skill-drivable**, the on-site presence must match the site's branding, and the archive must live on the site.
+
+The initial framing was "collect emails now, keep the newsletter dormant until subscribers arrive". This was rejected: a dormant list **decays** (subscribers who hear nothing for months mark the first send as spam), and — specific to this setup — the domain already sends **transactional** mail (the contact form) through Resend, so newsletter spam complaints would poison deliverability for real mail. The counter-fear (maintaining a newsletter for zero readers) is only valid if each issue is new writing; it is defused by the **harvest** model, where an issue is ~90% auto-assembled from content that already exists in the repo, costing minutes per month and producing a durable archive artifact regardless of audience size.
+
+The research compared Kit, Buttondown, Resend, beehiiv, MailerLite, EmailOctopus, Listmonk, and Ghost. Kit won on paper for its free-tier archive API. But once the decision was made to **own the content in-repo** (the harvest sources — `src/content/blog`, `talks.json`, etc. — already live here), the provider's archive API became irrelevant, which reshaped the tool choice. MailerLite and EmailOctopus were eliminated outright (no issue HTML by API and no free-tier API sending); beehiiv gates its Send API to paid; Ghost requires paid Mailgun; Listmonk is free software but needs a paid/fragile host + Postgres + SMTP relay.
+
+## Decision
+
+Build a **hybrid** newsletter: the **site owns content, form, archive, and the "read on web" link**; a provider owns **subscriber storage, double opt-in, unsubscribe, and delivery**. Because the provider's archive API is no longer needed, the provider is chosen on free ceiling + double opt-in + HTML-send via API — the winner is **Kit (formerly ConvertKit), free "Newsletter" plan** ($0 to 10,000 subscribers, unlimited sends, API keys on all plans).
+
+Specifics settled with the decision:
+
+1. **Start now, no open dormancy.** Publish-then-collect: issue #1 goes out at the end of the first month the form is live, to whoever subscribed, with Davide as the first subscriber (validating the full pipeline end-to-end). An empty month (no new posts or talks) is **skipped**, not padded.
+2. **Content = harvest, owned in-repo.** Each issue is a short hand-written intro + auto-assembled sections (blog posts in the window, upcoming talks, optional projects/OSS) + optional per-issue curation. The intro is the non-negotiable minimum of voice.
+3. **One frozen `.mdx` file per issue** in `src/content/newsletter/` (e.g. `2026-07.mdx`), mirroring the blog. Content is **snapshotted at generation time** ("photograph, not mirror"): the archive shows what was actually sent and never rewrites itself if source content changes later. The same file is the single source for both the email HTML and the archive page, so they cannot diverge.
+4. **Kit's role is delivery + compliance only.** The site's own subscribe form POSTs to a server action that creates the subscriber via the Kit API, triggering Kit's double opt-in. Issue HTML is generated in-repo and sent via Kit's broadcast API. The email's "read on web" link points at the site's own `/newsletter/[slug]`, not Kit's hosted archive.
+5. **Resend stays for transactional only** (contact form). Separating transactional (Resend) from marketing (Kit) is also good deliverability hygiene.
+6. **On-site footprint:** a `/newsletter` page (pitch + form + archive index + `[slug]` detail), a text-only link in the footer, a compact subscribe form at the end of each blog post, compact CTAs on Home and Sharing (the Sharing pitch framed around "upcoming talks"), and a post-confirmation landing page. One reusable form component with `full` and `compact` modes. Other pages get nothing, to keep the site's sober tone.
+7. **Cadence:** monthly, end of month, **assisted** send — a dedicated skill drafts the issue, Davide reviews/edits the intro and triggers the send by hand. No automated cron send at this stage.
+8. **A dedicated newsletter skill** orchestrates: read the month's window from the repo (`src/content/blog` by date, `talks.json` for upcoming) **and the content-os MCP** (Calendar / published Pieces / metrics) for the cross-channel view → draft the frozen `.mdx` (harvest + suggested intro + upcoming) → generate email HTML → create a Kit broadcast **draft** with the on-site "read on web" URL → stop for human review. Same philosophy as `write-blog-post` / `social-post`.
+9. **Email HTML via react-email** (React components → email-safe HTML, provider-agnostic), styled toward the site brand within the limits of email clients (custom fonts are commonly stripped, so approximate).
+10. **Compliance:** double opt-in (the EU consent-proof standard, effectively required), plus Kit-managed unsubscribe / `List-Unsubscribe` header and a conforming sender footer.
+
+## Consequences
+
+- **Cost is $0** and stays there until the list is large enough to justify paying (well past MVP): Kit free covers 10,000 subscribers with unlimited sends; react-email, the content-os MCP, and the in-repo content are already free.
+- **Two email systems on the domain** (Resend transactional + Kit marketing) — accepted, and a deliverability positive rather than a negative.
+- **Full front-end ownership** of form, archive, branding, and the "read on web" link, at the cost of building those (a known, one-time build; the contact-form + Turnstile pattern is reusable for the subscribe form).
+- **The frozen-snapshot model** means the generation skill must copy source content into the issue file at draft time; editing a blog post later will not retro-change a past issue (intended).
+- **Two pre-build verifications** flagged by the research, each a ~2-minute live test with a free Kit API key: (a) that broadcast **sending** via API works on the free Newsletter plan (Kit's docs confirm unrestricted API keys but never state free-tier sending explicitly, unlike MailerLite which explicitly forbids it — so this is verified-by-inference); (b) that a subscriber **created via the API** triggers Kit's double opt-in confirmation email (vs. having to route through a Kit Form).
+- **Deferred to v2, explicitly out of MVP:** automated cron send, own open/click analytics, a preference center, segments/tags, and RSS-to-email automation.
+- If Kit's free tier ever stops fitting, the exit is cheap: content and archive already live in-repo, so only the delivery/subscriber layer would need swapping (Buttondown was the research runner-up; its 100-subscriber free cap is the only reason it lost).

--- a/docs/research/kit-api-verification-spike.md
+++ b/docs/research/kit-api-verification-spike.md
@@ -2,19 +2,17 @@
 
 **Issue:** [#71](https://github.com/davideimola/davideimola.dev/issues/71) (parent PRD [#70](https://github.com/davideimola/davideimola.dev/issues/70)) · **ADR:** [ADR-0002](../adr/0002-newsletter-hybrid-kit-in-repo-content.md) · **Research:** [newsletter-free-tier-comparison](./newsletter-free-tier-comparison.md)
 
-> **Live-run status: PENDING.** The endpoint shapes below are pre-filled from the Kit v4
-> documentation so the integration issues (#72–#77) have a contract to build against. The
-> two assumptions this spike exists to prove — free-tier API **send** and API-created
-> **double opt-in** — are marked `LIVE RESULT: pending` and must be filled from an actual
-> run of `scripts/verify-kit-free-tier.mjs` against a real free-tier key **before** the
-> integration code is written. Do not treat the pre-filled shapes as confirmed until the
-> run output has been transcribed here.
+> **Live-run status: RUN 2026-07-22** against a real free-tier account (plan `free`,
+> 10,000-subscriber limit). Auth, subscriber-create, form-subscribe, and broadcast-create
+> are confirmed below. **Broadcast _send_ (criterion 1) is not yet executed** — see its
+> section. **The double opt-in assumption FAILED** — the v4 API has no confirmation-email
+> flow; a fallback is required (see the verdict). Re-run `scripts/verify-kit-free-tier.mjs`
+> to reproduce.
 
 ## Why this spike
 
 The research recommended Kit's free "Newsletter" plan, but two load-bearing facts were
-only **verified-by-inference** (Kit's docs confirm unrestricted API keys but never state
-free-tier sending outright, unlike MailerLite which explicitly forbids it):
+only **verified-by-inference**:
 
 1. Creating **and sending** a broadcast via the API works on the free Newsletter plan.
 2. A subscriber **created via the API** triggers Kit's double opt-in confirmation email —
@@ -28,163 +26,167 @@ If either fails, the fallback must be known before any integration code is writt
 ```bash
 KIT_API_KEY=<free-tier v4 key> \
 KIT_TEST_EMAIL=<an inbox you control> \
-KIT_FORM_ID=<double-opt-in form id, optional> \
+KIT_FORM_ID=<form id OR uid, optional> \
 node scripts/verify-kit-free-tier.mjs            # draft only, no email sent
 
 # add --send to perform a REAL scheduled broadcast send (5 min out, cancellable)
+# add --cleanup to delete created drafts (and cancel a scheduled send)
 # add --json findings.json to write a machine-readable summary
 ```
 
-The harness prints every request/response verbatim (API key redacted). Transcribe the
-observed shapes into the sections below and flip the verdicts. Note the harness can only
-observe subscriber **state** via the API — whether the confirmation and broadcast emails
-actually **land** is a manual inbox check.
+The harness prints every request/response verbatim (API key redacted). It can only observe
+subscriber **state** via the API — whether a confirmation/broadcast email actually **lands**
+is a manual inbox check.
 
-## Authentication
+## Authentication — CONFIRMED
 
-- **Mechanism:** a **v4** API key in the `X-Kit-Api-Key` request header. This is a single
-  key (not the v3 `api_key` + `api_secret` pair, which the integration does not use).
-  Generate it at Kit → Settings → Developer. Free Kit accounts do not support OAuth, but
-  API keys are unrestricted on every plan including free.
+- **Mechanism:** a **v4** API key in the `X-Kit-Api-Key` request header. A single key (not
+  the v3 `api_key` + `api_secret` pair — see the double-opt-in note, where v3 matters).
+  Generate at Kit → Settings → Developer. Free accounts don't support OAuth; API keys are
+  unrestricted on every plan including free.
 - **Base URL:** `https://api.kit.com/v4`
-- **Server-side only:** the key is consumed by a server action and the digest skill and
-  must never reach the client. Env var is `KIT_API_KEY` (no `NEXT_PUBLIC_` prefix).
+- **Server-side only:** consumed by the subscribe server action and the digest skill; never
+  reaches the client. Env var `KIT_API_KEY` (no `NEXT_PUBLIC_` prefix).
 
-```
-GET https://api.kit.com/v4/account
-X-Kit-Api-Key: <key>
-Accept: application/json
-```
-
-> `LIVE RESULT: pending` — confirm the key is accepted (200) and record the account/plan
-> fields returned.
+`GET /v4/account` → `200`. Confirms the key, and that this account is on `plan_type: "free"`
+with `subscriber_limit: 10000` and a verified sending address (`is_verified: true`).
 
 ## Subscriber creation
 
-Two candidate paths. The spike determines which one the subscribe action must use.
-
-### Path A — direct: `POST /v4/subscribers`
+### Path A — direct: `POST /v4/subscribers` — CONFIRMED, no double opt-in
 
 ```
-POST /v4/subscribers
-X-Kit-Api-Key: <key>
-Content-Type: application/json
-
-{ "email_address": "reader@example.com" }
+POST /v4/subscribers    { "email_address": "reader@example.com" }
 ```
 
-Expected response (from v4 docs — confirm shape against the run):
+Response `200/201`:
 
 ```jsonc
 {
   "subscriber": {
-    "id": 123456789,
+    "id": 4219670893,
+    "first_name": null,
     "email_address": "reader@example.com",
-    "state": "active",          // ← the field that decides double opt-in
-    "created_at": "2026-07-22T…",
-    "fields": { }
+    "state": "active",        // ← created ACTIVE with NO confirmation email
+    "created_at": "2026-07-22T…Z",
+    "fields": {}
   }
 }
 ```
 
-- If `state` is `active` immediately → **no double opt-in** on this path; Path B is required.
-- If `state` is `inactive` → confirmation pending (double opt-in in effect).
+Accepts `first_name`, `email_address` (required), `state` (`active` | `inactive` | `cancelled`
+| `bounced` | `complained`, **defaults to `active`**), and `fields`. You _can_ pass
+`state: "inactive"`, but the endpoint **sends no confirmation email** and its own docs warn
+"Updating the subscriber state with this endpoint is not supported" — so an `inactive`
+subscriber created this way has no way to self-confirm. **This path never triggers double
+opt-in.**
 
-> `LIVE RESULT: pending` — record the observed `state` for the direct path.
+### Path B — associate with a Form: `POST /v4/forms/{id}/subscribers` — CONFIRMED, not an opt-in flow
 
-### Path B — via Form (double opt-in fallback): `POST /v4/forms/{form_id}/subscribers`
+Two gotchas confirmed live:
 
-```
-POST /v4/forms/<KIT_FORM_ID>/subscribers
-X-Kit-Api-Key: <key>
-Content-Type: application/json
-
-{ "email_address": "reader@example.com" }
-```
-
-A subscriber added through a Form that has double opt-in enabled comes back `inactive`
-and Kit sends the confirmation email; the subscriber becomes `active` only after they
-click confirm. Discover available forms with `GET /v4/forms` (the harness lists them,
-showing each form's `settings.opt_in_required`).
-
-> `LIVE RESULT: pending` — record the observed `state` for the form path and whether the
-> confirmation email arrived in the test inbox.
+1. **id vs uid.** The API path wants the numeric form **`id`** (e.g. `9713978`). The embed
+   URL/JS uses the string **`uid`** (e.g. `2484145147`). Passing the uid returns `404`. The
+   harness resolves either form of `KIT_FORM_ID` against `GET /v4/forms` to the numeric id.
+2. **The subscriber must already exist.** Per the v4 docs, this endpoint _associates an
+   existing subscriber with a form_ — it does **not** create one. Posting an unknown email
+   returns `404 "Not Found"`. Posting an **existing** subscriber returns `201` with an
+   `added_at` timestamp — and the subscriber's `state` is unchanged (stays `active`). **No
+   confirmation email is sent; this is not a double opt-in trigger.**
 
 ## Broadcast creation + send
 
-### Create (draft): `POST /v4/broadcasts`
+### Create (draft): `POST /v4/broadcasts` — CONFIRMED
 
 ```
-POST /v4/broadcasts
-X-Kit-Api-Key: <key>
-Content-Type: application/json
-
-{
-  "subject": "…",
-  "content": "<p>email HTML…</p>",
-  "public": false
-}
+POST /v4/broadcasts    { "subject": "…", "content": "<p>…</p>", "public": false }
 ```
 
-Expected response (from v4 docs — confirm shape against the run):
+Response `201`:
 
 ```jsonc
 {
   "broadcast": {
-    "id": 987654321,
+    "id": 25108320,
+    "publication_id": 21713461,
+    "created_at": "2026-07-22T…Z",
     "subject": "…",
-    "content": "<p>email HTML…</p>",
     "preview_text": null,
+    "description": null,
     "public": false,
     "published_at": null,
     "send_at": null,
-    "status": "draft"
+    "status": "draft",
+    "content": "<p>…</p>",
+    "public_url": "https://<account>.kit.com/posts/",
+    "email_address": "hello@davideimola.dev",       // the account sending address
+    "email_template": { "id": 4686515, "name": "Davide Imola Simple" },
+    "subscriber_filter": [ { "all": [ { "type": "all_subscribers" } ] } ]  // ← default audience
   }
 }
 ```
 
-> `LIVE RESULT: pending` — confirm a draft is created (2xx) and record the returned `id`
-> and `status`.
+Note the default `subscriber_filter` is **all_subscribers** — a send with no narrower filter
+goes to the entire list. (At spike time the account had exactly **1** subscriber, so a test
+send only reaches the author.)
 
-### Send / schedule: `send_at` on `POST /v4/broadcasts`
+### Send / schedule: `send_at` on `POST /v4/broadcasts` — NOT YET TESTED
 
-The free-tier send assumption is the whole point of the spike. Per the primary source
-([newsletter-free-tier-comparison](./newsletter-free-tier-comparison.md)), `POST /v4/broadcasts`
-with a `send_at` ISO-8601 timestamp **schedules the send** — there is no separate "send" verb.
-The harness (with `--send`) creates a broadcast with `send_at` a few minutes out and reports
-whether the free plan accepts it or returns a plan-restriction error (a `402`/`403` would be
-the MailerLite-style hard block the research warned about).
+Per the primary source, `POST /v4/broadcasts` with a `send_at` ISO-8601 timestamp
+**schedules the send** (no separate "send" verb). The harness `--send` creates a broadcast
+with `send_at` a few minutes out and reports whether the free plan accepts it (2xx) or
+returns a plan restriction (`402`/`403`, the MailerLite-style block the research warned of).
 
 ```
-POST /v4/broadcasts
-{ "subject": "…", "content": "<p>…</p>", "public": false, "send_at": "2026-07-22T…Z" }
+POST /v4/broadcasts   { "subject": "…", "content": "<p>…</p>", "public": false, "send_at": "…Z" }
 ```
 
-> `LIVE RESULT: pending` — confirm the free plan accepts a scheduled send (2xx) rather than
-> returning a plan restriction, and record the response shape and any send-time gotchas.
+> `LIVE RESULT: pending` — run with `--send` (safe: 1 subscriber = the author only), confirm
+> a 2xx / non-restricted response, then confirm the email lands. Use `--cleanup` to cancel.
 
 ## Verdicts
 
 | Assumption | Verdict | Evidence |
 |---|---|---|
-| Auth via `X-Kit-Api-Key` works on free tier | `pending` | `GET /v4/account` status |
-| Broadcast **create** works on free tier | `pending` | `POST /v4/broadcasts` status + id |
-| Broadcast **send** works on free tier | `pending` | `--send` result (allowed / plan-restricted) |
-| API-created subscriber triggers **double opt-in** | `pending` | direct vs form `state` + inbox check |
-| **Fallback needed?** (route via Kit Form) | `pending` | true iff direct path returns `active` |
+| Auth via `X-Kit-Api-Key` works on free tier | ✅ **CONFIRMED** | `GET /v4/account` → 200, `plan_type: free` |
+| Broadcast **create** works on free tier | ✅ **CONFIRMED** | `POST /v4/broadcasts` → 201, `status: draft` |
+| Broadcast **send** works on free tier | ⏳ **NOT YET TESTED** | needs a `--send` run |
+| API-created subscriber triggers **double opt-in** | ❌ **FAILED** | direct → `active`, no email; form-associate → state unchanged, no email |
+| **Fallback needed?** (route via Kit Form) | ⚠️ **YES — required** | see below |
+
+### Double opt-in: the assumption is false — fallback required
+
+The v4 API has **no double-opt-in / confirmation-email flow**. Neither creating a subscriber
+(`POST /v4/subscribers`) nor associating one with a form (`POST /v4/forms/{id}/subscribers`)
+sends a confirmation email; the first creates an `active` subscriber outright, the second
+leaves the state as-is. Kit's confirmation email belongs to the **form-submission** flow,
+not the admin API. Options for a compliant double opt-in, to decide before building #74:
+
+1. **Legacy v3 form-subscribe API** — `POST /v3/forms/{form_id}/subscribe` (needs a separate
+   **v3** API key; the v4 key returns `401` there). Historically triggers the confirmation
+   email when the form has opt-in enabled, keeping our own React form. **Risk:** v3 is
+   marked legacy/deprecated — building a new integration on it is fragile.
+2. **Kit embedded/hosted form** — Kit's JS embed or hosted page does native double opt-in,
+   but puts Kit's form UI in play, conflicting with ADR-0002's "site owns the form".
+3. **Single opt-in via v4 + logged consent** — `POST /v4/subscribers` (active immediately),
+   paired with an explicit consent checkbox + stored proof. Simpler and all-v4, but diverges
+   from ADR-0002's deliberate double-opt-in choice; revisit the ADR before choosing this.
+
+**This needs a decision (and likely an ADR-0002 update) before issue #74 is built.** It does
+not block #72/#73/#75/#77, which don't touch the subscribe path.
 
 ## Env vars (added by this spike)
 
-Added to `.env.local.example`, **server-side only**:
+Added to `.env.local.example`, **server-side only** (never `NEXT_PUBLIC_`):
 
-- `KIT_API_KEY` — v4 API key (`X-Kit-Api-Key` header). Never `NEXT_PUBLIC_`.
-- `KIT_FORM_ID` — id of the double-opt-in Kit Form subscribers are routed through, needed
-  only if Path A does not trigger double opt-in (to be settled by the live run).
+- `KIT_API_KEY` — v4 API key (`X-Kit-Api-Key` header).
+- `KIT_FORM_ID` — a Kit Form id (or uid; the harness resolves either). Whether it is used at
+  all depends on the double-opt-in decision above; if option 1 is chosen, a `v3` API key env
+  var would also be needed.
 
 ## What this unblocks
 
-Once the verdicts are filled and green, the integration issues can proceed against this
-contract: the Kit API client seam (#75's `createBroadcastDraft`, #74's `createSubscriber`),
-the subscribe server action (#74), and the digest skill (#77). If the send assumption
-fails, revisit ADR-0002 before building #75; if double opt-in requires a Form, #74's
-subscribe action targets Path B with `KIT_FORM_ID`.
+Broadcast create + auth are proven, so the digest→email→broadcast-draft path (#75, #77) and
+the archive/loader work (#72) can proceed against this contract. The **subscribe capability
+(#74) is gated** on the double-opt-in decision above. The broadcast **send** proof (#75's
+eventual send) should be closed with a `--send` run when convenient.

--- a/docs/research/kit-api-verification-spike.md
+++ b/docs/research/kit-api-verification-spike.md
@@ -147,6 +147,26 @@ So programmatic sending is available on the free Newsletter plan — the MailerL
 paywall the research warned about does **not** apply to Kit. (Delivery reaches the list per
 the `subscriber_filter`; the test send went to the sole subscriber, the author.)
 
+#### Deliverability note — the test send landed in spam
+
+The confirmed test send **delivered but landed in the Junk folder** (iCloud). Two causes,
+one of them a real pre-build finding:
+
+1. **Not representative content.** The test broadcast was a one-line, link-less body with an
+   `[SPIKE TEST] … — ignore` subject — textbook thin/spammy mail. A real issue (intro +
+   harvested sections + links + unsubscribe footer) starts from a much better baseline.
+2. **The domain is not authenticated for Kit sending.** `GET /v4/account` reports the sending
+   address as `is_verified: true` but **`is_dmarc_configured: false`**. A brand-new Kit sender
+   on `davideimola.dev` with no DMARC alignment, into a strict provider (iCloud), reliably
+   lands in spam. The domain already authenticates **Resend** (transactional), but **Kit's own
+   domain authentication (DKIM CNAMEs from Kit, SPF include, DMARC alignment) must be set up
+   before real issues go out.** This is separate from "can we send via API" (yes) — it governs
+   inbox placement.
+
+**Action for the build (before issue #1 ships):** complete Kit domain authentication for
+`davideimola.dev` and re-test placement. Tracked as a deliverability prerequisite, not an API
+limitation.
+
 ## Verdicts
 
 | Assumption | Verdict | Evidence |
@@ -190,6 +210,7 @@ Added to `.env.local.example`, **server-side only** (never `NEXT_PUBLIC_`):
 ## What this unblocks
 
 Auth, broadcast create, and broadcast send are all proven, so the digest→email→broadcast
-path (#75, #77) and the archive/loader work (#72) can proceed against this contract. The
-**subscribe capability (#74) is gated** on the double-opt-in decision above — that is the
-one open item this spike surfaced.
+path (#75, #77) and the archive/loader work (#72) can proceed against this contract. Two
+open items this spike surfaced: (1) the **subscribe capability (#74) is gated** on the
+double-opt-in decision above; (2) **Kit domain authentication** for `davideimola.dev` is a
+deliverability prerequisite before issue #1 ships (see the deliverability note).

--- a/docs/research/kit-api-verification-spike.md
+++ b/docs/research/kit-api-verification-spike.md
@@ -3,10 +3,11 @@
 **Issue:** [#71](https://github.com/davideimola/davideimola.dev/issues/71) (parent PRD [#70](https://github.com/davideimola/davideimola.dev/issues/70)) · **ADR:** [ADR-0002](../adr/0002-newsletter-hybrid-kit-in-repo-content.md) · **Research:** [newsletter-free-tier-comparison](./newsletter-free-tier-comparison.md)
 
 > **Live-run status: RUN 2026-07-22** against a real free-tier account (plan `free`,
-> 10,000-subscriber limit). Auth, subscriber-create, form-associate, broadcast-create, and
-> broadcast **send** are confirmed below. **The double opt-in assumption FAILED** — the v4
-> API has no confirmation-email flow; a fallback is required (see the verdict). Re-run
-> `scripts/verify-kit-free-tier.mjs` to reproduce.
+> 10,000-subscriber limit). **All four assumptions verified.** Auth, subscriber-create,
+> broadcast-create, and broadcast **send** work on the free plan; **double opt-in is
+> achievable via the v4 API** (create-inactive → associate with an opt-in Kit Form triggers
+> the confirmation email). One deliverability prerequisite surfaced (domain authentication).
+> Re-run `scripts/verify-kit-free-tier.mjs` to reproduce.
 
 ## Why this spike
 
@@ -25,8 +26,8 @@ If either fails, the fallback must be known before any integration code is writt
 ```bash
 KIT_API_KEY=<free-tier v4 key> \
 KIT_TEST_EMAIL=<an inbox you control> \
-KIT_FORM_ID=<form id OR uid, optional> \
-node scripts/verify-kit-free-tier.mjs            # draft only, no email sent
+KIT_FORM_ID=<double-opt-in form id OR uid> \
+node scripts/verify-kit-free-tier.mjs            # draft only, no broadcast sent
 
 # add --send to perform a REAL scheduled broadcast send (5 min out, cancellable)
 # add --cleanup to delete created drafts (and cancel a scheduled send)
@@ -40,58 +41,69 @@ is a manual inbox check.
 ## Authentication — CONFIRMED
 
 - **Mechanism:** a **v4** API key in the `X-Kit-Api-Key` request header. A single key (not
-  the v3 `api_key` + `api_secret` pair — see the double-opt-in note, where v3 matters).
-  Generate at Kit → Settings → Developer. Free accounts don't support OAuth; API keys are
-  unrestricted on every plan including free.
+  the v3 `api_key` + `api_secret` pair; the v3 key is a different credential and is **not
+  needed** — double opt-in works on v4, see below). Generate at Kit → Settings → Developer.
+  Free accounts don't support OAuth; API keys are unrestricted on every plan including free.
 - **Base URL:** `https://api.kit.com/v4`
 - **Server-side only:** consumed by the subscribe server action and the digest skill; never
   reaches the client. Env var `KIT_API_KEY` (no `NEXT_PUBLIC_` prefix).
 
 `GET /v4/account` → `200`. Confirms the key, and that this account is on `plan_type: "free"`
-with `subscriber_limit: 10000` and a verified sending address (`is_verified: true`).
+with `subscriber_limit: 10000` and a verified sending address (`is_verified: true`, but note
+`is_dmarc_configured: false` — see the deliverability note).
 
-## Subscriber creation
+## Subscriber creation & double opt-in — CONFIRMED (two-call flow)
 
-### Path A — direct: `POST /v4/subscribers` — CONFIRMED, no double opt-in
+Double opt-in **is achievable on v4**, but not through a single call. The confirmation email
+is a **Form** behavior, so the flow is: create the subscriber `inactive`, then associate it
+with a double-opt-in-enabled Kit Form, which sends Kit's "confirm your subscription" email.
+
+### Step 1 — create the subscriber (as inactive): `POST /v4/subscribers`
 
 ```
-POST /v4/subscribers    { "email_address": "reader@example.com" }
+POST /v4/subscribers    { "email_address": "reader@example.com", "state": "inactive" }
 ```
 
-Response `200/201`:
+Response `201`:
 
 ```jsonc
-{
-  "subscriber": {
-    "id": 4219670893,
-    "first_name": null,
-    "email_address": "reader@example.com",
-    "state": "active",        // ← created ACTIVE with NO confirmation email
-    "created_at": "2026-07-22T…Z",
-    "fields": {}
-  }
-}
+{ "subscriber": { "id": 4219900293, "email_address": "reader@example.com", "state": "inactive", … } }
 ```
 
 Accepts `first_name`, `email_address` (required), `state` (`active` | `inactive` | `cancelled`
-| `bounced` | `complained`, **defaults to `active`**), and `fields`. You _can_ pass
-`state: "inactive"`, but the endpoint **sends no confirmation email** and its own docs warn
-"Updating the subscriber state with this endpoint is not supported" — so an `inactive`
-subscriber created this way has no way to self-confirm. **This path never triggers double
-opt-in.**
+| `bounced` | `complained`, **defaults to `active`**), and `fields`. **Creating a subscriber
+alone sends no email** — with the default `active` state it silently subscribes them (no
+double opt-in). Passing `state: "inactive"` creates a pending record, again with no email
+yet; the confirmation email comes from step 2. (Note: this endpoint's docs warn "Updating the
+subscriber state with this endpoint is not supported", so set the state at creation.)
 
-### Path B — associate with a Form: `POST /v4/forms/{id}/subscribers` — CONFIRMED, not an opt-in flow
+### Step 2 — associate with a double-opt-in Form: `POST /v4/forms/{id}/subscribers`
+
+```
+POST /v4/forms/9713978/subscribers    { "email_address": "reader@example.com" }
+```
 
 Two gotchas confirmed live:
 
 1. **id vs uid.** The API path wants the numeric form **`id`** (e.g. `9713978`). The embed
    URL/JS uses the string **`uid`** (e.g. `2484145147`). Passing the uid returns `404`. The
    harness resolves either form of `KIT_FORM_ID` against `GET /v4/forms` to the numeric id.
-2. **The subscriber must already exist.** Per the v4 docs, this endpoint _associates an
-   existing subscriber with a form_ — it does **not** create one. Posting an unknown email
-   returns `404 "Not Found"`. Posting an **existing** subscriber returns `201` with an
-   `added_at` timestamp — and the subscriber's `state` is unchanged (stays `active`). **No
-   confirmation email is sent; this is not a double opt-in trigger.**
+2. **The subscriber must already exist** (hence step 1). Posting an unknown email returns
+   `404 "Not Found"`; posting an existing one returns `201` with `added_at`, preserving the
+   subscriber's `state`.
+
+**When the form has double opt-in enabled, this call triggers Kit's confirmation email** —
+observed live: for the `inactive` subscriber created in step 1, Kit sent an
+`"Important: confirm your subscription"` email from `hello@davideimola.dev` with a **"Confirm
+your subscription"** button and a compliant `Unsubscribe · Privacy` footer, and the subscriber
+stayed `inactive` (pending). Clicking the button confirms them → `active`. That is exactly the
+double opt-in ADR-0002 requires, and it needs no v3 API and no embedded Kit form.
+
+> The double-opt-in behavior lives in the **form's settings**, which the v4 `GET /v4/forms`
+> list does not expose — so the target form must have double opt-in turned on in the Kit UI,
+> and `KIT_FORM_ID` must point at it. Associating an already-`active` subscriber also sends the
+> email but does not gate anything (they are already subscribed), so the `inactive`-first
+> order matters.
 
 ## Broadcast creation + send
 
@@ -108,10 +120,8 @@ Response `201`:
   "broadcast": {
     "id": 25108320,
     "publication_id": 21713461,
-    "created_at": "2026-07-22T…Z",
     "subject": "…",
     "preview_text": null,
-    "description": null,
     "public": false,
     "published_at": null,
     "send_at": null,
@@ -125,9 +135,9 @@ Response `201`:
 }
 ```
 
-Note the default `subscriber_filter` is **all_subscribers** — a send with no narrower filter
-goes to the entire list. (At spike time the account had exactly **1** subscriber, so a test
-send only reaches the author.)
+The default `subscriber_filter` is **all_subscribers** — a send with no narrower filter goes
+to the whole list. The `email_template` is a pre-existing account template; it can be changed
+later and is not a spike concern.
 
 ### Send / schedule: `send_at` on `POST /v4/broadcasts` — CONFIRMED
 
@@ -135,17 +145,12 @@ send only reaches the author.)
 "send" verb). Live result: the free plan **accepted** the scheduled send — `201`, no plan
 restriction (no `402`/`403`):
 
-```
-POST /v4/broadcasts   { "subject": "…", "content": "<p>…</p>", "public": false, "send_at": "…Z" }
-```
-
 ```jsonc
 { "broadcast": { "id": 25109796, "send_at": "2026-07-22T15:57:55Z", "status": "scheduled", … } }
 ```
 
 So programmatic sending is available on the free Newsletter plan — the MailerLite-style
-paywall the research warned about does **not** apply to Kit. (Delivery reaches the list per
-the `subscriber_filter`; the test send went to the sole subscriber, the author.)
+paywall the research warned about does **not** apply to Kit.
 
 #### Deliverability note — the test send landed in spam
 
@@ -174,43 +179,36 @@ limitation.
 | Auth via `X-Kit-Api-Key` works on free tier | ✅ **CONFIRMED** | `GET /v4/account` → 200, `plan_type: free` |
 | Broadcast **create** works on free tier | ✅ **CONFIRMED** | `POST /v4/broadcasts` → 201, `status: draft` |
 | Broadcast **send** works on free tier | ✅ **CONFIRMED** | `POST /v4/broadcasts` + `send_at` → 201, `status: scheduled`, no plan block |
-| API-created subscriber triggers **double opt-in** | ❌ **FAILED** | direct → `active`, no email; form-associate → state unchanged, no email |
-| **Fallback needed?** (route via Kit Form) | ⚠️ **YES — required** | see below |
+| API-created subscriber triggers **double opt-in** | ✅ **CONFIRMED (two-call)** | create `inactive` → associate with opt-in form → Kit sent the "confirm your subscription" email; subscriber stayed `inactive` |
+| Deliverability / inbox placement | ⚠️ **NEEDS DOMAIN AUTH** | test send hit spam; `is_dmarc_configured: false` |
 
-### Double opt-in: the assumption is false — fallback required
+### Double opt-in verdict (corrected)
 
-The v4 API has **no double-opt-in / confirmation-email flow**. Neither creating a subscriber
-(`POST /v4/subscribers`) nor associating one with a form (`POST /v4/forms/{id}/subscribers`)
-sends a confirmation email; the first creates an `active` subscriber outright, the second
-leaves the state as-is. Kit's confirmation email belongs to the **form-submission** flow,
-not the admin API. Options for a compliant double opt-in, to decide before building #74:
+An earlier draft of this doc concluded double opt-in was impossible on v4 — **that was wrong**,
+based on testing only an already-`active` subscriber. The correct finding: **double opt-in works
+on v4** via the two-call flow (create `inactive` → `POST /v4/forms/{id}/subscribers` against a
+double-opt-in form). The subscribe capability (#74) can therefore build a clean, all-v4 flow:
 
-1. **Legacy v3 form-subscribe API** — `POST /v3/forms/{form_id}/subscribe` (needs a separate
-   **v3** API key; the v4 key returns `401` there). Historically triggers the confirmation
-   email when the form has opt-in enabled, keeping our own React form. **Risk:** v3 is
-   marked legacy/deprecated — building a new integration on it is fragile.
-2. **Kit embedded/hosted form** — Kit's JS embed or hosted page does native double opt-in,
-   but puts Kit's form UI in play, conflicting with ADR-0002's "site owns the form".
-3. **Single opt-in via v4 + logged consent** — `POST /v4/subscribers` (active immediately),
-   paired with an explicit consent checkbox + stored proof. Simpler and all-v4, but diverges
-   from ADR-0002's deliberate double-opt-in choice; revisit the ADR before choosing this.
+1. Our own React form → subscribe server action (honeypot + Turnstile, per the contact-form pattern).
+2. `POST /v4/subscribers { email_address, state: "inactive" }`.
+3. `POST /v4/forms/{KIT_FORM_ID}/subscribers { email_address }` → Kit sends the confirmation email.
+4. The subscriber clicks "Confirm your subscription" → Kit flips them to `active` and (per the
+   form's setting) can redirect to our on-site "you're in" landing page.
 
-**This needs a decision (and likely an ADR-0002 update) before issue #74 is built.** It does
-not block #72/#73/#75/#77, which don't touch the subscribe path.
+No v3 API (deprecated) and no embedded Kit form are needed.
 
 ## Env vars (added by this spike)
 
 Added to `.env.local.example`, **server-side only** (never `NEXT_PUBLIC_`):
 
 - `KIT_API_KEY` — v4 API key (`X-Kit-Api-Key` header).
-- `KIT_FORM_ID` — a Kit Form id (or uid; the harness resolves either). Whether it is used at
-  all depends on the double-opt-in decision above; if option 1 is chosen, a `v3` API key env
-  var would also be needed.
+- `KIT_FORM_ID` — the numeric id (or uid; the harness resolves either) of a Kit Form with
+  **double opt-in enabled**, used in step 2 of the subscribe flow.
 
 ## What this unblocks
 
-Auth, broadcast create, and broadcast send are all proven, so the digest→email→broadcast
-path (#75, #77) and the archive/loader work (#72) can proceed against this contract. Two
-open items this spike surfaced: (1) the **subscribe capability (#74) is gated** on the
-double-opt-in decision above; (2) **Kit domain authentication** for `davideimola.dev` is a
-deliverability prerequisite before issue #1 ships (see the deliverability note).
+Auth, broadcast create + send, and the double-opt-in subscribe flow are all proven, so the
+integration issues can proceed against this contract: the subscribe capability (#74, the
+two-call flow above), the digest→email→broadcast path (#75, #77), and the archive/loader
+work (#72). The one remaining prerequisite is **Kit domain authentication** for
+`davideimola.dev` (deliverability), which should be completed before issue #1 ships.

--- a/docs/research/kit-api-verification-spike.md
+++ b/docs/research/kit-api-verification-spike.md
@@ -3,11 +3,10 @@
 **Issue:** [#71](https://github.com/davideimola/davideimola.dev/issues/71) (parent PRD [#70](https://github.com/davideimola/davideimola.dev/issues/70)) · **ADR:** [ADR-0002](../adr/0002-newsletter-hybrid-kit-in-repo-content.md) · **Research:** [newsletter-free-tier-comparison](./newsletter-free-tier-comparison.md)
 
 > **Live-run status: RUN 2026-07-22** against a real free-tier account (plan `free`,
-> 10,000-subscriber limit). Auth, subscriber-create, form-subscribe, and broadcast-create
-> are confirmed below. **Broadcast _send_ (criterion 1) is not yet executed** — see its
-> section. **The double opt-in assumption FAILED** — the v4 API has no confirmation-email
-> flow; a fallback is required (see the verdict). Re-run `scripts/verify-kit-free-tier.mjs`
-> to reproduce.
+> 10,000-subscriber limit). Auth, subscriber-create, form-associate, broadcast-create, and
+> broadcast **send** are confirmed below. **The double opt-in assumption FAILED** — the v4
+> API has no confirmation-email flow; a fallback is required (see the verdict). Re-run
+> `scripts/verify-kit-free-tier.mjs` to reproduce.
 
 ## Why this spike
 
@@ -130,19 +129,23 @@ Note the default `subscriber_filter` is **all_subscribers** — a send with no n
 goes to the entire list. (At spike time the account had exactly **1** subscriber, so a test
 send only reaches the author.)
 
-### Send / schedule: `send_at` on `POST /v4/broadcasts` — NOT YET TESTED
+### Send / schedule: `send_at` on `POST /v4/broadcasts` — CONFIRMED
 
-Per the primary source, `POST /v4/broadcasts` with a `send_at` ISO-8601 timestamp
-**schedules the send** (no separate "send" verb). The harness `--send` creates a broadcast
-with `send_at` a few minutes out and reports whether the free plan accepts it (2xx) or
-returns a plan restriction (`402`/`403`, the MailerLite-style block the research warned of).
+`POST /v4/broadcasts` with a `send_at` ISO-8601 timestamp **schedules the send** (no separate
+"send" verb). Live result: the free plan **accepted** the scheduled send — `201`, no plan
+restriction (no `402`/`403`):
 
 ```
 POST /v4/broadcasts   { "subject": "…", "content": "<p>…</p>", "public": false, "send_at": "…Z" }
 ```
 
-> `LIVE RESULT: pending` — run with `--send` (safe: 1 subscriber = the author only), confirm
-> a 2xx / non-restricted response, then confirm the email lands. Use `--cleanup` to cancel.
+```jsonc
+{ "broadcast": { "id": 25109796, "send_at": "2026-07-22T15:57:55Z", "status": "scheduled", … } }
+```
+
+So programmatic sending is available on the free Newsletter plan — the MailerLite-style
+paywall the research warned about does **not** apply to Kit. (Delivery reaches the list per
+the `subscriber_filter`; the test send went to the sole subscriber, the author.)
 
 ## Verdicts
 
@@ -150,7 +153,7 @@ POST /v4/broadcasts   { "subject": "…", "content": "<p>…</p>", "public": fal
 |---|---|---|
 | Auth via `X-Kit-Api-Key` works on free tier | ✅ **CONFIRMED** | `GET /v4/account` → 200, `plan_type: free` |
 | Broadcast **create** works on free tier | ✅ **CONFIRMED** | `POST /v4/broadcasts` → 201, `status: draft` |
-| Broadcast **send** works on free tier | ⏳ **NOT YET TESTED** | needs a `--send` run |
+| Broadcast **send** works on free tier | ✅ **CONFIRMED** | `POST /v4/broadcasts` + `send_at` → 201, `status: scheduled`, no plan block |
 | API-created subscriber triggers **double opt-in** | ❌ **FAILED** | direct → `active`, no email; form-associate → state unchanged, no email |
 | **Fallback needed?** (route via Kit Form) | ⚠️ **YES — required** | see below |
 
@@ -186,7 +189,7 @@ Added to `.env.local.example`, **server-side only** (never `NEXT_PUBLIC_`):
 
 ## What this unblocks
 
-Broadcast create + auth are proven, so the digest→email→broadcast-draft path (#75, #77) and
-the archive/loader work (#72) can proceed against this contract. The **subscribe capability
-(#74) is gated** on the double-opt-in decision above. The broadcast **send** proof (#75's
-eventual send) should be closed with a `--send` run when convenient.
+Auth, broadcast create, and broadcast send are all proven, so the digest→email→broadcast
+path (#75, #77) and the archive/loader work (#72) can proceed against this contract. The
+**subscribe capability (#74) is gated** on the double-opt-in decision above — that is the
+one open item this spike surfaced.

--- a/docs/research/kit-api-verification-spike.md
+++ b/docs/research/kit-api-verification-spike.md
@@ -1,0 +1,190 @@
+# Kit free-tier verification spike — API contract + findings
+
+**Issue:** [#71](https://github.com/davideimola/davideimola.dev/issues/71) (parent PRD [#70](https://github.com/davideimola/davideimola.dev/issues/70)) · **ADR:** [ADR-0002](../adr/0002-newsletter-hybrid-kit-in-repo-content.md) · **Research:** [newsletter-free-tier-comparison](./newsletter-free-tier-comparison.md)
+
+> **Live-run status: PENDING.** The endpoint shapes below are pre-filled from the Kit v4
+> documentation so the integration issues (#72–#77) have a contract to build against. The
+> two assumptions this spike exists to prove — free-tier API **send** and API-created
+> **double opt-in** — are marked `LIVE RESULT: pending` and must be filled from an actual
+> run of `scripts/verify-kit-free-tier.mjs` against a real free-tier key **before** the
+> integration code is written. Do not treat the pre-filled shapes as confirmed until the
+> run output has been transcribed here.
+
+## Why this spike
+
+The research recommended Kit's free "Newsletter" plan, but two load-bearing facts were
+only **verified-by-inference** (Kit's docs confirm unrestricted API keys but never state
+free-tier sending outright, unlike MailerLite which explicitly forbids it):
+
+1. Creating **and sending** a broadcast via the API works on the free Newsletter plan.
+2. A subscriber **created via the API** triggers Kit's double opt-in confirmation email —
+   rather than requiring the subscribe flow to route through a Kit **Form**.
+
+If either fails, the fallback must be known before any integration code is written (issue
+#74's subscribe capability in particular). This document is that pre-build gate.
+
+## How to run the verification
+
+```bash
+KIT_API_KEY=<free-tier v4 key> \
+KIT_TEST_EMAIL=<an inbox you control> \
+KIT_FORM_ID=<double-opt-in form id, optional> \
+node scripts/verify-kit-free-tier.mjs            # draft only, no email sent
+
+# add --send to perform a REAL scheduled broadcast send (5 min out, cancellable)
+# add --json findings.json to write a machine-readable summary
+```
+
+The harness prints every request/response verbatim (API key redacted). Transcribe the
+observed shapes into the sections below and flip the verdicts. Note the harness can only
+observe subscriber **state** via the API — whether the confirmation and broadcast emails
+actually **land** is a manual inbox check.
+
+## Authentication
+
+- **Mechanism:** a **v4** API key in the `X-Kit-Api-Key` request header. This is a single
+  key (not the v3 `api_key` + `api_secret` pair, which the integration does not use).
+  Generate it at Kit → Settings → Developer. Free Kit accounts do not support OAuth, but
+  API keys are unrestricted on every plan including free.
+- **Base URL:** `https://api.kit.com/v4`
+- **Server-side only:** the key is consumed by a server action and the digest skill and
+  must never reach the client. Env var is `KIT_API_KEY` (no `NEXT_PUBLIC_` prefix).
+
+```
+GET https://api.kit.com/v4/account
+X-Kit-Api-Key: <key>
+Accept: application/json
+```
+
+> `LIVE RESULT: pending` — confirm the key is accepted (200) and record the account/plan
+> fields returned.
+
+## Subscriber creation
+
+Two candidate paths. The spike determines which one the subscribe action must use.
+
+### Path A — direct: `POST /v4/subscribers`
+
+```
+POST /v4/subscribers
+X-Kit-Api-Key: <key>
+Content-Type: application/json
+
+{ "email_address": "reader@example.com" }
+```
+
+Expected response (from v4 docs — confirm shape against the run):
+
+```jsonc
+{
+  "subscriber": {
+    "id": 123456789,
+    "email_address": "reader@example.com",
+    "state": "active",          // ← the field that decides double opt-in
+    "created_at": "2026-07-22T…",
+    "fields": { }
+  }
+}
+```
+
+- If `state` is `active` immediately → **no double opt-in** on this path; Path B is required.
+- If `state` is `inactive` → confirmation pending (double opt-in in effect).
+
+> `LIVE RESULT: pending` — record the observed `state` for the direct path.
+
+### Path B — via Form (double opt-in fallback): `POST /v4/forms/{form_id}/subscribers`
+
+```
+POST /v4/forms/<KIT_FORM_ID>/subscribers
+X-Kit-Api-Key: <key>
+Content-Type: application/json
+
+{ "email_address": "reader@example.com" }
+```
+
+A subscriber added through a Form that has double opt-in enabled comes back `inactive`
+and Kit sends the confirmation email; the subscriber becomes `active` only after they
+click confirm. Discover available forms with `GET /v4/forms` (the harness lists them,
+showing each form's `settings.opt_in_required`).
+
+> `LIVE RESULT: pending` — record the observed `state` for the form path and whether the
+> confirmation email arrived in the test inbox.
+
+## Broadcast creation + send
+
+### Create (draft): `POST /v4/broadcasts`
+
+```
+POST /v4/broadcasts
+X-Kit-Api-Key: <key>
+Content-Type: application/json
+
+{
+  "subject": "…",
+  "content": "<p>email HTML…</p>",
+  "public": false
+}
+```
+
+Expected response (from v4 docs — confirm shape against the run):
+
+```jsonc
+{
+  "broadcast": {
+    "id": 987654321,
+    "subject": "…",
+    "content": "<p>email HTML…</p>",
+    "preview_text": null,
+    "public": false,
+    "published_at": null,
+    "send_at": null,
+    "status": "draft"
+  }
+}
+```
+
+> `LIVE RESULT: pending` — confirm a draft is created (2xx) and record the returned `id`
+> and `status`.
+
+### Send / schedule: `send_at` on `POST /v4/broadcasts`
+
+The free-tier send assumption is the whole point of the spike. Per the primary source
+([newsletter-free-tier-comparison](./newsletter-free-tier-comparison.md)), `POST /v4/broadcasts`
+with a `send_at` ISO-8601 timestamp **schedules the send** — there is no separate "send" verb.
+The harness (with `--send`) creates a broadcast with `send_at` a few minutes out and reports
+whether the free plan accepts it or returns a plan-restriction error (a `402`/`403` would be
+the MailerLite-style hard block the research warned about).
+
+```
+POST /v4/broadcasts
+{ "subject": "…", "content": "<p>…</p>", "public": false, "send_at": "2026-07-22T…Z" }
+```
+
+> `LIVE RESULT: pending` — confirm the free plan accepts a scheduled send (2xx) rather than
+> returning a plan restriction, and record the response shape and any send-time gotchas.
+
+## Verdicts
+
+| Assumption | Verdict | Evidence |
+|---|---|---|
+| Auth via `X-Kit-Api-Key` works on free tier | `pending` | `GET /v4/account` status |
+| Broadcast **create** works on free tier | `pending` | `POST /v4/broadcasts` status + id |
+| Broadcast **send** works on free tier | `pending` | `--send` result (allowed / plan-restricted) |
+| API-created subscriber triggers **double opt-in** | `pending` | direct vs form `state` + inbox check |
+| **Fallback needed?** (route via Kit Form) | `pending` | true iff direct path returns `active` |
+
+## Env vars (added by this spike)
+
+Added to `.env.local.example`, **server-side only**:
+
+- `KIT_API_KEY` — v4 API key (`X-Kit-Api-Key` header). Never `NEXT_PUBLIC_`.
+- `KIT_FORM_ID` — id of the double-opt-in Kit Form subscribers are routed through, needed
+  only if Path A does not trigger double opt-in (to be settled by the live run).
+
+## What this unblocks
+
+Once the verdicts are filled and green, the integration issues can proceed against this
+contract: the Kit API client seam (#75's `createBroadcastDraft`, #74's `createSubscriber`),
+the subscribe server action (#74), and the digest skill (#77). If the send assumption
+fails, revisit ADR-0002 before building #75; if double opt-in requires a Form, #74's
+subscribe action targets Path B with `KIT_FORM_ID`.

--- a/docs/research/newsletter-free-tier-comparison.md
+++ b/docs/research/newsletter-free-tier-comparison.md
@@ -1,0 +1,176 @@
+# Free-tier newsletter/email tool comparison: which one gives a queryable archive API at $0?
+
+**Research date: 2026-07-22.** Free-tier limits and API surfaces change often — every number and endpoint below was verified against the primary source linked next to it on this date. Re-verify before acting on this months from now.
+
+Scope: davideimola.dev (Next.js 16 App Router, Vercel Hobby). Goal: pick one newsletter tool that (1) costs **nothing** at this stage — the newsletter may stay dormant until the first subscribers arrive, so any recurring fee is waste; (2) exposes a **queryable archive API on the free tier** — an endpoint to LIST sent issues AND fetch each issue's rendered HTML/content — so a `/newsletter` archive page can be built on the site; (3) is **code-manageable** (a real REST API/SDK, scriptable, integratable via skills); (4) supports **subscription capture + one monthly digest**. Constraint #2 is the decision-driver and eliminates most candidates.
+
+Note on Resend: it is already wired into this repo (`RESEND_API_KEY` exists for the contact form) but was never used as a newsletter tool, so there is **zero lock-in** and it neither blocks nor privileges anything. It is evaluated on equal footing below.
+
+## TL;DR / Recommendation
+
+- **Winner: Kit (formerly ConvertKit), free "Newsletter" plan.** It is the only tool that satisfies all four constraints without a caveat that hurts: **$0 up to 10,000 subscribers with unlimited sends** ([Kit Newsletter plan](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan)), API keys are **unrestricted on every plan including free** ([Kit API overview](https://help.kit.com/en/articles/9902901-kit-api-overview)), and — critically — both `GET /v4/broadcasts` and `GET /v4/broadcasts/{id}` return the broadcast's **`content` (HTML)** field directly ([list broadcasts](https://developers.kit.com/api-reference/broadcasts/list-broadcasts), [get a broadcast](https://developers.kit.com/api-reference/broadcasts/get-a-broadcast)). So the `/newsletter` archive page is buildable from the API on the free tier, Kit sends the email itself (no external SMTP), and broadcasts are created/scheduled via `POST /v4/broadcasts` with `send_at` ([create a broadcast](https://developers.kit.com/api-reference/broadcasts/create-a-broadcast)).
+- **Runner-up: Buttondown.** The cleanest developer-first API and archive of the lot — API on all plans including free ([features/API FAQ](https://buttondown.com/features/api)), hosted archives free, `GET /emails` + `GET /emails/{id}` return the issue body ([listing emails](https://docs.buttondown.com/api-emails-list), [retrieving email](https://docs.buttondown.com/api-emails-retrieve)), and it auto-handles SPF/DKIM even on a custom domain for free ([custom-domain sending](https://buttondown.com/blog/deliverability)). **The trade-off is the free cap: 100 subscribers** ([Buttondown pricing](https://buttondown.com/pricing)) — fine to start a dormant list, but you outgrow it far sooner than Kit's 10,000.
+- **Pragmatic in-repo option: Resend Broadcasts.** Already present, zero lock-in, real REST API on all plans, and `GET /broadcasts/{id}` returns `html` + `text` ([get broadcast](https://resend.com/docs/api-reference/broadcasts/get-broadcast)). But the list endpoint returns **metadata only** (no HTML), so the archive needs an N+1 fetch ([list broadcasts](https://resend.com/docs/api-reference/broadcasts/list-broadcasts)); the free audience caps at **1,000 contacts** ([pricing](https://resend.com/pricing)); it is a raw sending API with **no hosted subscription/archive pages** (you build all of it); and it needs a DNS-verified sending domain ([domains](https://resend.com/docs/dashboard/domains/introduction)).
+- **The archive-API requirement is the hard blocker that eliminates the rest:**
+  - **MailerLite** — `GET /api/campaigns/{id}` returns **`plain_text` only, no rendered HTML** ([campaigns API](https://developers.mailerlite.com/docs/campaigns.html)), and **sending via API is paid-only**: "On Free, API and MCP access is limited and doesn't include sending" ([pricing](https://www.mailerlite.com/pricing)). Double blocker.
+  - **EmailOctopus** — API v2 can list/get campaigns but **cannot create or send them and does not expose campaign HTML** ([v2 API](https://emailoctopus.com/api-documentation/v2)). Blocked on both send-by-code and archive-HTML.
+  - **beehiiv** — the read API (posts + rendered HTML via `expand`) IS free, but **the Send API is gated to paid**, so programmatic sending is not available on the free Launch plan ([pricing](https://www.beehiiv.com/pricing)). Good archive, no code-send at $0.
+  - **Ghost (self-host)** — fails zero-cost: bulk newsletter sending **requires Mailgun, the only supported provider** ("bulk email can't be done with basic SMTP") ([Ghost newsletters](https://docs.ghost.org/newsletters)), and Mailgun no longer has a durable free tier; Ghost(Pro) has no free plan ([pricing](https://ghost.org/pricing/)).
+  - **Listmonk (self-host)** — genuinely free OSS with a full archive API, but it is not zero-*ops*/zero-*cost* in practice: it needs a host + Postgres + a bring-your-own SMTP relay ([install](https://listmonk.app/docs/installation/), [homepage](https://listmonk.app/)).
+
+## Comparison table (hard numbers)
+
+Tools as rows (there are eight); attributes as columns. "Archive API" is split into the two things the `/newsletter` page needs: an endpoint to **list** sent issues, and an endpoint to fetch each issue's **rendered HTML**.
+
+| Tool | Free cost | Max subs (free) | Sends/mo (free) | List sent issues (API) | Get rendered HTML (API) | Create/send via API on free | Sends email itself | Branding on free |
+|---|---|---|---|---|---|---|---|---|
+| **Kit** (Newsletter) | $0 [→](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan) | 10,000 [→](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan) | Unlimited [→](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan) | Yes — `GET /v4/broadcasts` [→](https://developers.kit.com/api-reference/broadcasts/list-broadcasts) | **Yes — `content` (HTML)** [→](https://developers.kit.com/api-reference/broadcasts/get-a-broadcast) | Yes — API keys unrestricted on all plans [→](https://help.kit.com/en/articles/9902901-kit-api-overview) | Yes | UNVERIFIED |
+| **Buttondown** | $0 [→](https://buttondown.com/pricing) | 100 [→](https://buttondown.com/pricing) | not numerically capped on free (UNVERIFIED) | Yes — `GET /emails` [→](https://docs.buttondown.com/api-emails-list) | **Yes — `GET /emails/{id}` body** [→](https://docs.buttondown.com/api-emails-retrieve) | Yes — API on all plans [→](https://buttondown.com/features/api) | Yes [→](https://buttondown.com/blog/deliverability) | No (UNVERIFIED) |
+| **Resend** (Broadcasts) | $0 [→](https://resend.com/pricing) | 1,000 contacts [→](https://resend.com/pricing) | 3,000 (100/day cap) [→](https://resend.com/pricing) | Yes — `GET /broadcasts` (metadata only) [→](https://resend.com/docs/api-reference/broadcasts/list-broadcasts) | **Yes — `GET /broadcasts/{id}` `html`+`text`** [→](https://resend.com/docs/api-reference/broadcasts/get-broadcast) | Yes — API on all plans [→](https://resend.com/pricing) | Yes (needs verified domain) [→](https://resend.com/docs/dashboard/domains/introduction) | No (UNVERIFIED) |
+| **beehiiv** (Launch) | $0 [→](https://www.beehiiv.com/pricing) | 2,500 [→](https://www.beehiiv.com/pricing) | Unlimited [→](https://www.beehiiv.com/pricing) | Yes — `GET /v2/publications/{id}/posts` [→](https://developers.beehiiv.com/api-reference/posts/index) | **Yes — `expand=free_email_content`** [→](https://developers.beehiiv.com/api-reference/posts/show) | **No — Send API paid** [→](https://www.beehiiv.com/pricing) | Yes | Yes (branding on free) [→](https://www.beehiiv.com/pricing) |
+| **MailerLite** | $0 [→](https://www.mailerlite.com/pricing) | 250 [→](https://www.mailerlite.com/pricing) | 2,500 [→](https://www.mailerlite.com/pricing) | Yes — `GET /api/campaigns` [→](https://developers.mailerlite.com/docs/campaigns.html) | **No — `plain_text` only** [→](https://developers.mailerlite.com/docs/campaigns.html) | **No — sending via API is paid-only** [→](https://www.mailerlite.com/pricing) | Yes | Yes (logo on free) [→](https://www.mailerlite.com/pricing) |
+| **EmailOctopus** | $0 [→](https://emailoctopus.com/pricing) | 2,500 [→](https://emailoctopus.com/pricing) | 10,000 [→](https://emailoctopus.com/pricing) | Yes — `GET /campaigns` (v2) [→](https://emailoctopus.com/api-documentation/v2) | **No — content not exposed** [→](https://emailoctopus.com/api-documentation/v2) | **No — v2 cannot create/send** [→](https://emailoctopus.com/api-documentation/v2) | Yes (on Amazon SES) | Yes (branding on free) [→](https://emailoctopus.com/pricing) |
+| **Listmonk** (self-host) | $0 software; needs host + SMTP [→](https://listmonk.app/docs/installation/) | unlimited (your DB) | unlimited (your SMTP) | Yes — `GET /api/campaigns` [→](https://listmonk.app/docs/apis/campaigns/) | **Yes — `GET /api/campaigns/{id}/preview`** [→](https://listmonk.app/docs/apis/campaigns/) | Yes — full REST API [→](https://listmonk.app/docs/apis/campaigns/) | No — bring your own SMTP relay [→](https://listmonk.app/) | No |
+| **Ghost** (self-host) | $0 software; needs host + Mailgun [→](https://docs.ghost.org/newsletters) | unlimited (your DB) | Mailgun-limited (not free) [→](https://docs.ghost.org/newsletters) | Content API posts [→](https://ghost.org/docs/content-api/) | Content API `html` (web posts) [→](https://ghost.org/docs/content-api/) | Admin API | No — Mailgun required (only provider) [→](https://docs.ghost.org/newsletters) | No |
+
+## 1. Kit (formerly ConvertKit) — free "Newsletter" plan (recommended)
+
+Sources: [Kit Newsletter plan](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan), [Kit API overview](https://help.kit.com/en/articles/9902901-kit-api-overview), [developers.kit.com](https://developers.kit.com/api-reference/broadcasts/list-broadcasts).
+
+- **Free tier: "Up to 10,000 active, unique subscribers" with "Unlimited email sends"** ([Newsletter plan](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan)). Also free: unlimited forms/landing pages, a newsletter feed + creator profile, A/B testing, and "1 basic visual automation with 1 email sequence". Gated to the paid Creator plan ($39+/mo): unlimited visual automations/sequences, RSS campaigns, advanced rules/integrations ([same source](https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan)).
+- **API on the free tier: yes.** "V3 and V4 API keys are not restricted. This means creators on any plan can generate API keys and use them" ([API overview](https://help.kit.com/en/articles/9902901-kit-api-overview)). Free accounts use an **API key** (`X-Kit-Api-Key` header); OAuth is only required for publicly-listed apps, and "Free Kit accounts don't support OAuth" — but the API-key path is exactly what a single-site integration/skill needs.
+- **Archive API — list: `GET /v4/broadcasts`.** Returns per-broadcast `id`, `created_at`, `subject`, `preview_text`, `description`, **`content`**, `public`, `published_at`, `send_at`, `public_url`, `status`, etc. ([list broadcasts](https://developers.kit.com/api-reference/broadcasts/list-broadcasts)). Setting `slim=true` omits the expensive fields (`content`, `public_url`, …) for faster listing, so you can list cheaply and fetch bodies on demand.
+- **Archive API — rendered HTML: `GET /v4/broadcasts/{id}`** returns the broadcast object including **`content` (HTML)** — the body of the email — plus `public`, `public_url`, `published_at` ([get a broadcast](https://developers.kit.com/api-reference/broadcasts/get-a-broadcast)). This is the single most important fact for this decision: **Kit hands you the rendered HTML directly on the free tier.** Filter by `status`/`published_at` to show only sent issues.
+- **Send via API: `POST /v4/broadcasts`** creates a draft; providing a `send_at` ISO-8601 timestamp schedules the send, and `public: true` "publish[es] this broadcast to the web" newsletter feed ([create a broadcast](https://developers.kit.com/api-reference/broadcasts/create-a-broadcast)). So a monthly digest can be authored + scheduled from code/a skill. *Nuance:* Kit's docs confirm API keys are unrestricted on every plan, which implies broadcast creation/sending works on the free Newsletter plan; I did not find a sentence that literally says "sending broadcasts via API is allowed on Free" the way MailerLite explicitly *forbids* it, so treat free-tier API sending as **verified-by-inference, lightly UNVERIFIED** — worth a 2-minute live test with a free API key before committing.
+- **Deliverability:** Kit sends the email itself; no external SMTP to wire up. Custom-domain DKIM/authentication is a Kit-managed feature.
+- **Branding on free emails: UNVERIFIED** — the plan page does not state whether a "powered by Kit" footer appears on free-plan sends.
+- **Fit:** best overall. Free ceiling (10,000 subs) is effectively irrelevant for a dormant list, the archive API returns HTML with no gymnastics, and it is fully code-drivable.
+
+## 2. Buttondown — free plan (runner-up, cleanest API)
+
+Source: [Buttondown pricing](https://buttondown.com/pricing), [API docs](https://docs.buttondown.com/api-emails-list), [features/API](https://buttondown.com/features/api).
+
+- **Free tier: "your first 100 subscribers" at "Absolutely nothing"**, including "Hosted newsletter archives" ([pricing](https://buttondown.com/pricing)). The 100-subscriber cap is the only real constraint here.
+- **API on the free tier: yes, explicitly.** "The API is available on all plans, including free" ([features/API FAQ](https://buttondown.com/features/api)). There is also an official Buttondown CLI for local/scripted use ([CLI docs](https://docs.buttondown.com/buttondown-cli)).
+- **Archive API — list: `GET /emails`** lists "all of your emails, including drafts, scheduled, and sent emails" ([listing emails](https://docs.buttondown.com/api-emails-list)) — filter by `status` for sent issues.
+- **Archive API — body: `GET /emails/{id}`** returns the single email ([retrieving email](https://docs.buttondown.com/api-emails-retrieve)); the email **`body` is stored as either HTML or Markdown** (Buttondown auto-detects the editor mode, overridable via a `buttondown-editor-mode` comment — [API email object](https://docs.buttondown.com/api-emails-introduction)). For a site archive you render the Markdown/HTML yourself, or link to Buttondown's hosted archive page. *(The rendered HTML vs. Markdown exact field shape returned by the API is thinly documented publicly — treat the precise field names as lightly UNVERIFIED and confirm against a live call; that the body is retrievable is confirmed.)*
+- **Send via API: `POST /emails`** creates/sends emails ([creating an email](https://docs.buttondown.com/api-emails-create)); drafting/scheduling via API is documented ([drafting emails via the API](https://docs.buttondown.com/drafting-emails-via-the-api)).
+- **Deliverability:** Buttondown sends the email itself and **auto-configures SPF/DKIM for you, even on a custom domain, on the free plan** — "basic deliverability features should never be paywalled" ([deliverability](https://buttondown.com/blog/deliverability), [custom-domain sending](https://docs.buttondown.com/sending-from-a-custom-domain)). Custom-domain setup adds a CNAME pointing at a Buttondown proxy subdomain.
+- **Fit:** the nicest developer experience and the most "archive-native" of all hosted options (Markdown body + hosted archive + clean REST + CLI). Loses to Kit only on the 100-subscriber free ceiling.
+
+## 3. Resend — Broadcasts + Audiences (already in the repo)
+
+Source: [Resend pricing](https://resend.com/pricing), [Broadcasts API reference](https://resend.com/docs/api-reference/broadcasts/list-broadcasts).
+
+- **Free tier:** "3,000" emails/month "limited to 100 emails per day", **1,000 contacts**, 1 domain, 30-day data retention; "RESTful API, SMTP relay, official SDKs" are on **all plans** ([pricing](https://resend.com/pricing)).
+- **Archive API — list: `GET /broadcasts`** returns **metadata only** — `id`, `name`, `segment_id` (formerly `audience_id`), `status`, `created_at`, `scheduled_at`, `sent_at`. **No HTML in the list response** ([list broadcasts](https://resend.com/docs/api-reference/broadcasts/list-broadcasts)).
+- **Archive API — rendered HTML: `GET /broadcasts/{broadcast_id}`** returns the full object **including `html` and `text`** (plus `subject`, `preview_text`, `status`, `sent_at`, …) ([get broadcast](https://resend.com/docs/api-reference/broadcasts/get-broadcast)). So the archive is buildable, but it costs **one extra GET per issue (N+1)** since the list omits bodies.
+- **Send via API:** the Broadcast API has "6 endpoints for programmatically creating, updating, and sending broadcasts" ([Broadcast API](https://resend.com/blog/broadcast-api)); broadcasts send only to existing Audience contacts ([Audiences](https://resend.com/blog/manage-subscribers-using-resend-audiences)).
+- **Deliverability:** requires a **DNS-verified sending domain** (SPF + DKIM records); `onboarding@resend.dev` is "only suitable for initial testing" ([managing domains](https://resend.com/docs/dashboard/domains/introduction)). davideimola.dev already sends contact-form mail through Resend, so the domain may already be verified.
+- **The real gap:** Resend is a **sending API, not a newsletter product** — there is no hosted subscription page, no hosted archive, no unsubscribe/preference UI out of the box; you build subscription capture, the archive page, and compliance footers yourself. For a code-first owner that is acceptable, but it is materially more work than Kit or Buttondown, and the free **1,000-contact** ceiling is lower than Kit's 10,000.
+- **Fit:** the zero-lock-in pragmatic choice if you want everything in-house and already trust Resend; otherwise Kit gives you the archive HTML plus hosted subscription/archive scaffolding for free.
+
+## 4. beehiiv — free "Launch" plan (good archive, but no code-send at $0)
+
+Source: [beehiiv pricing](https://www.beehiiv.com/pricing), [beehiiv API](https://developers.beehiiv.com/api-reference/posts/index).
+
+- **Free Launch tier:** "up to 2,500 subscribers", "Unlimited Email Sends", and — per beehiiv's own pricing page — **"API Access (excluding Send API)"** ([pricing](https://www.beehiiv.com/pricing)). Removing beehiiv branding is a Max-tier feature, so **the free plan carries beehiiv branding**.
+- **Archive API — list + HTML: yes, free.** `GET /v2/publications/{publicationId}/posts` and `GET /v2/publications/{publicationId}/posts/{postId}` return post metadata, and the **`expand` query param** yields rendered HTML: `free_email_content` ("the email HTML rendered to a free reader"), `free_web_content`, `free_rss_content` ([list posts](https://developers.beehiiv.com/api-reference/posts/index), [get post](https://developers.beehiiv.com/api-reference/posts/show)). This is a clean, free archive API.
+- **Send via API: NOT on free.** Programmatic sending is the **Send API, which is excluded from Launch** ([pricing](https://www.beehiiv.com/pricing)). You can still author and send from beehiiv's dashboard on the free plan, but requirement #3 ("create/send campaigns programmatically") is **not met at $0** — sending would be dashboard-only.
+- **Fit:** excellent free archive API, but it fails the "code-manageable sending" constraint on the free tier, and forces beehiiv branding. If dashboard-only sending were acceptable, beehiiv would be a strong archive source; given the code-first requirement, Kit is better.
+
+## 5. MailerLite — blocked (no HTML in API, paid-only API sending)
+
+Source: [MailerLite pricing](https://www.mailerlite.com/pricing), [Campaigns API](https://developers.mailerlite.com/docs/campaigns.html).
+
+- **Free tier is small and shrinking:** "up to 250 subscribers", "2,500 monthly emails", "2 user seats", MailerLite logo on emails (removed only on Comfort+), max 3 active automations ([pricing](https://www.mailerlite.com/pricing)). *(This is materially smaller than the widely-quoted "1,000 subs / 12,000 emails" — that figure is stale; the current page says 250 / 2,500.)*
+- **Blocker 1 — no rendered HTML in the API:** `GET /api/campaigns` and `GET /api/campaigns/{id}` return content-related fields `plain_text`, `screenshot_url`, `preview_url` — the get-campaign response **does not include rendered HTML**, and there is **no documented GET endpoint that returns campaign content HTML** (HTML can only be *uploaded* at create time on Advanced plans) ([campaigns API](https://developers.mailerlite.com/docs/campaigns.html)). You cannot build an HTML archive from the API.
+- **Blocker 2 — no sending via API on free:** "Email sending via the API and MCP server is available on paid plans. On Free, API and MCP access is limited and doesn't include sending" ([pricing](https://www.mailerlite.com/pricing)).
+- **Fit:** ruled out on constraints #2 and #3 simultaneously.
+
+## 6. EmailOctopus — blocked (v2 can't send, content not exposed)
+
+Source: [EmailOctopus pricing](https://emailoctopus.com/pricing), [API v2](https://emailoctopus.com/api-documentation/v2).
+
+- **Free "Starter" tier:** "2,500 subscribers", "10,000 emails per month", **"EmailOctopus branding on emails"**, 30-day reports, 1 landing page, 1 form, 1 user ([pricing](https://emailoctopus.com/pricing)). Built on Amazon SES infrastructure.
+- **Blocker — API v2 is retrieval/reporting only:** v2 exposes `GET /campaigns`, `GET /campaigns/{id}`, and report endpoints, but **"does not provide endpoints to create campaigns, send campaigns, or access/modify campaign HTML content"** — it "focuses on managing lists, contacts, fields, automations, and reporting" ([API v2](https://emailoctopus.com/api-documentation/v2)). The old v1 API is "legacy and no longer actively maintained" ([v1 docs](https://emailoctopus.com/api-documentation)).
+- **Fit:** ruled out — cannot send by code and does not return issue HTML.
+
+## 7. Listmonk — self-hosted OSS (genuine archive API, but not zero-cost/zero-ops)
+
+Source: [listmonk.app](https://listmonk.app/), [install docs](https://listmonk.app/docs/installation/), [campaigns API](https://listmonk.app/docs/apis/campaigns/).
+
+- **Software is genuinely free:** "free and open source software licensed under AGPLv3", shipped as "a single binary" ([homepage](https://listmonk.app/)).
+- **Requirements:** "a simple binary application that requires a Postgres database instance to run" — "Postgres DB (⩾ 12)" ([install](https://listmonk.app/docs/installation/)). So you need somewhere to run a Go process **and** a Postgres instance.
+- **Archive API — yes, and it renders HTML:** `GET /api/campaigns` lists campaigns; `GET /api/campaigns/{id}` returns the campaign incl. the raw `body`; and **`GET /api/campaigns/{id}/preview` returns "the HTML body with template variables substituted"** ([campaigns API](https://listmonk.app/docs/apis/campaigns/)). There is also `PUT /api/campaigns/{id}/archive` to "publish campaign to public archive", and listmonk ships **built-in public archive pages** ([homepage](https://listmonk.app/)). This is the most complete archive story of any option — you own the data and the endpoints.
+- **Sending: bring your own SMTP relay.** Listmonk does not send mail itself; it drives "multi-SMTP e-mail queues" ([homepage](https://listmonk.app/)) and connects to any SMTP relay (Amazon SES, Postmark, etc.). You supply — and pay for — deliverability. SES is ~$0 at tiny volume but still an AWS account + DNS (SPF/DKIM) to manage.
+- **Real cost:** the software is $0 but a production deployment is not. A genuinely-free host is possible but fragile — the same free-Postgres caveats from the analytics note apply (Neon free auto-suspends compute after 5 idle minutes; Supabase free pauses a project after 1 week idle), and a persistent Go process is not a fit for Vercel's serverless model, so you'd add a second host (Fly.io/Railway free allowances, a $4–5/mo VPS, etc.). **UNVERIFIED** whether any current free host runs listmonk + Postgres reliably for free long-term.
+- **Fit:** the best answer *if* data ownership or an unlimited free ceiling becomes a hard requirement and you accept ongoing ops. For a dormant list that must cost nothing and require no babysitting, it is over-engineered versus Kit.
+
+## 8. Ghost (self-host) — blocked on zero-cost (Mailgun required)
+
+Source: [Ghost pricing](https://ghost.org/pricing/), [Ghost newsletters](https://docs.ghost.org/newsletters), [Content API](https://ghost.org/docs/content-api/).
+
+- **No free hosted tier:** Ghost(Pro) starts at "$18 USD / mo" (billed yearly); self-hosting the open-source software is the only free-of-license path ([pricing](https://ghost.org/pricing/)).
+- **Blocker — bulk email requires Mailgun:** "Delivering bulk email newsletters can't be done with basic SMTP. A bulk mail provider is a requirement" and **"At present, Mailgun is the only supported bulk email provider"** ([newsletters](https://docs.ghost.org/newsletters)). Mailgun no longer offers a durable free tier (its free allowance is a limited trial; paid Flex/Basic plans start around $15–35/mo — pricing figures are secondary/**UNVERIFIED** here, but the *requirement* to use Mailgun is primary). So self-hosted Ghost newsletters cannot run at $0.
+- **Archive API:** Ghost's Content API exposes posts with `html`, so an archive of **web-published** posts is buildable ([Content API](https://ghost.org/docs/content-api/)); email-only posts are excluded from the public Content API by default (**UNVERIFIED** exact behavior on current version).
+- **Fit:** ruled out on the zero-cost constraint (paid Mailgun) and on operational weight (self-host Node + MySQL).
+
+## Decision
+
+For "**free + queryable archive API on the free tier + code-manageable + monthly digest**", the archive-HTML requirement is what separates the field. Only **Kit**, **Buttondown**, **Resend**, **beehiiv**, and **Listmonk** expose rendered issue HTML by API at all; of those, **beehiiv can't send by code on free**, **Listmonk isn't truly free to run**, and **Resend needs an N+1 fetch and gives you no hosted newsletter scaffolding**. That leaves **Kit** (10,000-sub free ceiling, HTML `content` straight from the broadcasts API) as the winner and **Buttondown** (cleanest API/archive, but 100-sub free cap) as the runner-up. **MailerLite and EmailOctopus are eliminated outright** — neither returns issue HTML by API, and neither lets you send by code on the free tier.
+
+## Sources
+
+All consulted 2026-07-22.
+
+**Kit (ConvertKit)**
+- https://help.kit.com/en/articles/9053602-the-kit-newsletter-plan
+- https://help.kit.com/en/articles/9902901-kit-api-overview
+- https://developers.kit.com/api-reference/broadcasts/list-broadcasts
+- https://developers.kit.com/api-reference/broadcasts/get-a-broadcast
+- https://developers.kit.com/api-reference/broadcasts/create-a-broadcast
+
+**Buttondown**
+- https://buttondown.com/pricing
+- https://buttondown.com/features/api
+- https://docs.buttondown.com/api-emails-list
+- https://docs.buttondown.com/api-emails-retrieve
+- https://docs.buttondown.com/api-emails-introduction
+- https://docs.buttondown.com/api-emails-create
+- https://docs.buttondown.com/drafting-emails-via-the-api
+- https://docs.buttondown.com/buttondown-cli
+- https://buttondown.com/blog/deliverability
+- https://docs.buttondown.com/sending-from-a-custom-domain
+
+**Resend**
+- https://resend.com/pricing
+- https://resend.com/docs/api-reference/broadcasts/list-broadcasts
+- https://resend.com/docs/api-reference/broadcasts/get-broadcast
+- https://resend.com/blog/broadcast-api
+- https://resend.com/blog/manage-subscribers-using-resend-audiences
+- https://resend.com/docs/dashboard/domains/introduction
+
+**beehiiv**
+- https://www.beehiiv.com/pricing
+- https://developers.beehiiv.com/api-reference/posts/index
+- https://developers.beehiiv.com/api-reference/posts/show
+
+**MailerLite**
+- https://www.mailerlite.com/pricing
+- https://developers.mailerlite.com/docs/campaigns.html
+
+**EmailOctopus**
+- https://emailoctopus.com/pricing
+- https://emailoctopus.com/api-documentation/v2
+- https://emailoctopus.com/api-documentation
+
+**Listmonk**
+- https://listmonk.app/
+- https://listmonk.app/docs/installation/
+- https://listmonk.app/docs/apis/campaigns/
+
+**Ghost**
+- https://ghost.org/pricing/
+- https://docs.ghost.org/newsletters
+- https://ghost.org/docs/content-api/

--- a/scripts/verify-kit-free-tier.mjs
+++ b/scripts/verify-kit-free-tier.mjs
@@ -85,6 +85,15 @@ function classifySubscriber(data) {
   return { state, doubleOptIn };
 }
 
+// The direct-path test (step 1) makes TEST_EMAIL `active`, and Kit will not re-send a
+// confirmation to an already-active subscriber — so the Form path (step 3) must use a
+// DISTINCT address or its double opt-in can never be observed. A plus-tag keeps it in
+// the same inbox (davide@x.com → davide+form@x.com) while being a new subscriber to Kit.
+function plusTag(email, tag) {
+  const [local, domain] = email.split("@");
+  return domain ? `${local}+${tag}@${domain}` : email;
+}
+
 // Single place that talks to Kit. Logs the request (key redacted) and the response
 // verbatim so the real contract is captured no matter what the shapes turn out to be.
 async function kit(method, path, body) {
@@ -178,23 +187,35 @@ console.log("  come back INACTIVE (double opt-in pending) or ACTIVE (no confirma
 
 // ── 2. Form subscriber create (the double opt-in fallback path) ──────────────────
 section("2. Discover forms — GET /forms");
-let resolvedFormId = FORM_ID;
+let resolvedFormId = null;
 {
   const { ok, data } = await kit("GET", "/forms");
   const forms = data?.forms ?? [];
   if (ok && forms.length) {
-    console.log("  Forms found (id — name — format — required double opt-in?):");
+    // The v4 list does NOT expose the double-opt-in setting, so it can't be printed
+    // here — it is observed empirically from the subscriber state in step 3.
+    console.log("  Forms found (id — uid — name — format):");
     for (const f of forms) {
-      console.log(
-        `   • ${f.id} — ${f.name} — ${f.format ?? "?"} — ${f.settings?.opt_in_required ?? "?"}`
-      );
+      console.log(`   • id=${f.id} — uid=${f.uid ?? "?"} — ${f.name} — ${f.format ?? "?"}`);
     }
-    if (!resolvedFormId) {
+    // The API expects the numeric `id`; the embed URL/JS uses the string `uid`. Accept
+    // either in KIT_FORM_ID and resolve to the numeric id so the URL gotcha can't bite.
+    if (FORM_ID) {
+      const match = forms.find(
+        (f) => String(f.id) === String(FORM_ID) || f.uid === String(FORM_ID)
+      );
+      if (match) {
+        resolvedFormId = match.id;
+        if (String(match.id) !== String(FORM_ID)) {
+          console.log(`  KIT_FORM_ID=${FORM_ID} is a uid → resolved to numeric id ${match.id}.`);
+        }
+      } else {
+        console.log(`  ⚠ KIT_FORM_ID=${FORM_ID} matches no form id/uid — the form path will 404.`);
+      }
+    } else {
       resolvedFormId = forms[0].id;
       console.log(`  No KIT_FORM_ID set — defaulting to the first form: ${resolvedFormId}`);
-      console.log(
-        "  For a clean test, set KIT_FORM_ID to a form with double opt-in enabled and re-run."
-      );
+      console.log("  For a clean test, set KIT_FORM_ID to a form with double opt-in enabled.");
     }
   } else {
     console.log(
@@ -204,11 +225,14 @@ let resolvedFormId = FORM_ID;
 }
 
 if (resolvedFormId) {
+  // Distinct address from the direct test so double opt-in can actually be observed.
+  const formEmail = plusTag(TEST_EMAIL, "form");
   section(`3. Form subscriber — POST /forms/${resolvedFormId}/subscribers { email_address }`);
+  console.log(`  Using a fresh address for this path: ${formEmail}`);
   findings.formSubscriber.attempted = true;
   findings.formSubscriber.formId = resolvedFormId;
   const { ok, data } = await kit("POST", `/forms/${resolvedFormId}/subscribers`, {
-    email_address: TEST_EMAIL,
+    email_address: formEmail,
   });
   const { state, doubleOptIn } = classifySubscriber(data);
   findings.formSubscriber.state = state;
@@ -217,7 +241,7 @@ if (resolvedFormId) {
     console.log(`  → resulting state: ${state ?? "(not reported)"}`);
     console.log(
       doubleOptIn === true
-        ? `  ✓ state=inactive → double opt-in pending via the Form path. CONFIRM the email arrived in ${TEST_EMAIL}.`
+        ? `  ✓ state=inactive → double opt-in pending via the Form path. CONFIRM the email arrived in ${formEmail}.`
         : "  ⚠ state is not 'inactive' via the Form — the form may not have double opt-in enabled."
     );
   }

--- a/scripts/verify-kit-free-tier.mjs
+++ b/scripts/verify-kit-free-tier.mjs
@@ -1,0 +1,353 @@
+// Throwaway verification spike for the Kit (formerly ConvertKit) free "Newsletter" plan.
+//
+// Why this exists: ADR-0002 / issue #71. The newsletter integration rests on two
+// assumptions that the research (docs/research/newsletter-free-tier-comparison.md)
+// could only verify by inference:
+//   (a) creating AND sending a broadcast via the Kit API works on the free plan, and
+//   (b) a subscriber CREATED VIA THE API triggers Kit's double opt-in confirmation
+//       email — or, if not, whether routing through a Kit Form is required.
+// This probe answers both against a live free-tier key BEFORE any integration code
+// is written. It is deliberately dependency-free (native fetch on Node 22) and prints
+// every request/response verbatim so the exact contract can be transcribed into
+// docs/research/kit-api-verification-spike.md.
+//
+// It is a one-shot spike harness, not production code and not a CI test: it talks to
+// the live Kit API, creates a real subscriber, and (with --send) sends a real email.
+//
+// Usage:
+//   KIT_API_KEY=... KIT_TEST_EMAIL=you@example.com node scripts/verify-kit-free-tier.mjs
+//
+// Env:
+//   KIT_API_KEY    (required) v4 API key — sent as the X-Kit-Api-Key header.
+//   KIT_TEST_EMAIL (required) an inbox you control; used for BOTH the subscriber
+//                  tests and the broadcast recipient. Use a real inbox so you can
+//                  confirm the double opt-in / broadcast emails actually arrive.
+//   KIT_FORM_ID    (optional) id of a double-opt-in-enabled Kit Form. If unset, the
+//                  form path is skipped and the script prints the forms it found so
+//                  you can pick one and re-run.
+//
+// Flags:
+//   --send     Actually schedule/send the test broadcast (default: create a draft
+//              only, never send). The broadcast is scheduled a few minutes out so it
+//              can be cancelled from the Kit dashboard if needed.
+//   --cleanup  Delete the artifacts this run creates (test broadcast draft; the test
+//              subscriber is left in place so you can inspect the confirmation email).
+//   --json <path>  Write the machine-readable findings summary to <path>.
+//
+// Re-verify before trusting: Kit's free-tier limits and API surfaces change (the
+// research notes this explicitly). Re-run this months from now rather than assuming.
+
+const BASE_URL = "https://api.kit.com/v4";
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const optValue = (name) => {
+  const i = args.indexOf(name);
+  return i !== -1 && i + 1 < args.length ? args[i + 1] : undefined;
+};
+
+const API_KEY = process.env.KIT_API_KEY;
+const TEST_EMAIL = process.env.KIT_TEST_EMAIL;
+const FORM_ID = process.env.KIT_FORM_ID;
+const DO_SEND = flag("--send");
+const DO_CLEANUP = flag("--cleanup");
+const JSON_OUT = optValue("--json");
+
+// Findings we accumulate and print (and optionally write) at the end.
+const findings = {
+  ranAt: new Date().toISOString(),
+  base_url: BASE_URL,
+  auth: { header: "X-Kit-Api-Key", ok: null, account: null },
+  directSubscriber: { attempted: false, state: null, doubleOptIn: null },
+  formSubscriber: { attempted: false, formId: FORM_ID ?? null, state: null, doubleOptIn: null },
+  broadcastCreate: { attempted: false, id: null, status: null, ok: null },
+  broadcastSend: { attempted: false, ok: null, planRestricted: null, sendAt: null },
+  verdicts: {},
+};
+
+function redact(key) {
+  if (!key) return "(unset)";
+  return key.length <= 8 ? "****" : `${key.slice(0, 4)}…${key.slice(-2)}`;
+}
+
+function section(title) {
+  console.log(`\n${"─".repeat(72)}\n${title}\n${"─".repeat(72)}`);
+}
+
+// Classify a subscriber-create response into { state, doubleOptIn }. Kit subscriber
+// states are: active | inactive | bounced | complained | cancelled. Only `inactive`
+// means "double opt-in pending" (awaiting the confirmation click); `active` means the
+// subscriber is live with NO confirmation step; any other state (bounced, etc.) is not
+// a double-opt-in signal and is reported as inconclusive (null) rather than mis-read.
+function classifySubscriber(data) {
+  const state = (data?.subscriber ?? data)?.state ?? null;
+  const doubleOptIn = state === "inactive" ? true : state === "active" ? false : null;
+  return { state, doubleOptIn };
+}
+
+// Single place that talks to Kit. Logs the request (key redacted) and the response
+// verbatim so the real contract is captured no matter what the shapes turn out to be.
+async function kit(method, path, body) {
+  const url = `${BASE_URL}${path}`;
+  console.log(`\n→ ${method} ${url}`);
+  console.log(
+    `  headers: { "X-Kit-Api-Key": "${redact(API_KEY)}", "Content-Type": "application/json" }`
+  );
+  if (body !== undefined) console.log(`  body: ${JSON.stringify(body)}`);
+
+  let res;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: {
+        "X-Kit-Api-Key": API_KEY,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    console.log(`  ✗ network error: ${err.message}`);
+    return { status: 0, ok: false, data: null, error: err };
+  }
+
+  const text = await res.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text; // non-JSON response — keep the raw text
+  }
+  console.log(`← ${res.status} ${res.statusText}`);
+  console.log(`  body: ${typeof data === "string" ? data : JSON.stringify(data, null, 2)}`);
+  return { status: res.status, ok: res.ok, data };
+}
+
+function fail(message) {
+  console.error(`\n✗ ${message}`);
+  process.exit(1);
+}
+
+// ── Preconditions ─────────────────────────────────────────────────────────────
+if (!API_KEY)
+  fail("KIT_API_KEY is required. Create a free-tier key in Kit → Settings → Developer.");
+if (!TEST_EMAIL) fail("KIT_TEST_EMAIL is required. Use a real inbox you control.");
+
+console.log("Kit free-tier verification spike (issue #71)");
+console.log(`  api key:    ${redact(API_KEY)}`);
+console.log(`  test email: ${TEST_EMAIL}`);
+console.log(`  form id:    ${FORM_ID ?? "(none — form path will be skipped)"}`);
+console.log(
+  `  send:       ${DO_SEND ? "YES — a real broadcast will be scheduled" : "no (draft only)"}`
+);
+console.log(`  cleanup:    ${DO_CLEANUP ? "yes" : "no"}`);
+
+// ── 0. Auth sanity check ────────────────────────────────────────────────────────
+section("0. Auth — GET /account (confirms the X-Kit-Api-Key header is accepted)");
+{
+  const { ok, data } = await kit("GET", "/account");
+  findings.auth.ok = ok;
+  findings.auth.account = ok ? (data?.account ?? data) : null;
+  if (!ok) fail("Auth failed. The API key is rejected — fix it before continuing.");
+  console.log("  ✓ API key accepted.");
+}
+
+// ── 1. Direct subscriber create (does POST /subscribers trigger double opt-in?) ──
+section("1. Direct subscriber — POST /subscribers { email_address }");
+console.log("  Assumption under test: does a subscriber created directly via the API");
+console.log("  come back INACTIVE (double opt-in pending) or ACTIVE (no confirmation)?");
+{
+  findings.directSubscriber.attempted = true;
+  const { ok, data } = await kit("POST", "/subscribers", { email_address: TEST_EMAIL });
+  const { state, doubleOptIn } = classifySubscriber(data);
+  findings.directSubscriber.state = state;
+  findings.directSubscriber.doubleOptIn = doubleOptIn;
+  if (ok) {
+    console.log(`  → resulting state: ${state ?? "(not reported)"}`);
+    console.log(
+      doubleOptIn === false
+        ? "  ⚠ state=active → NO double opt-in on the direct path. The Form path (step 2) is REQUIRED."
+        : doubleOptIn === true
+          ? `  → state=inactive → double opt-in pending. CONFIRM the email arrived in ${TEST_EMAIL}.`
+          : `  → state=${state} → not an opt-in signal; inspect the response above.`
+    );
+  } else {
+    console.log("  ⚠ direct create failed — see response above.");
+  }
+}
+
+// ── 2. Form subscriber create (the double opt-in fallback path) ──────────────────
+section("2. Discover forms — GET /forms");
+let resolvedFormId = FORM_ID;
+{
+  const { ok, data } = await kit("GET", "/forms");
+  const forms = data?.forms ?? [];
+  if (ok && forms.length) {
+    console.log("  Forms found (id — name — format — required double opt-in?):");
+    for (const f of forms) {
+      console.log(
+        `   • ${f.id} — ${f.name} — ${f.format ?? "?"} — ${f.settings?.opt_in_required ?? "?"}`
+      );
+    }
+    if (!resolvedFormId) {
+      resolvedFormId = forms[0].id;
+      console.log(`  No KIT_FORM_ID set — defaulting to the first form: ${resolvedFormId}`);
+      console.log(
+        "  For a clean test, set KIT_FORM_ID to a form with double opt-in enabled and re-run."
+      );
+    }
+  } else {
+    console.log(
+      "  ⚠ No forms found (or the call failed). Create a double-opt-in Form in Kit and set KIT_FORM_ID."
+    );
+  }
+}
+
+if (resolvedFormId) {
+  section(`3. Form subscriber — POST /forms/${resolvedFormId}/subscribers { email_address }`);
+  findings.formSubscriber.attempted = true;
+  findings.formSubscriber.formId = resolvedFormId;
+  const { ok, data } = await kit("POST", `/forms/${resolvedFormId}/subscribers`, {
+    email_address: TEST_EMAIL,
+  });
+  const { state, doubleOptIn } = classifySubscriber(data);
+  findings.formSubscriber.state = state;
+  findings.formSubscriber.doubleOptIn = doubleOptIn;
+  if (ok) {
+    console.log(`  → resulting state: ${state ?? "(not reported)"}`);
+    console.log(
+      doubleOptIn === true
+        ? `  ✓ state=inactive → double opt-in pending via the Form path. CONFIRM the email arrived in ${TEST_EMAIL}.`
+        : "  ⚠ state is not 'inactive' via the Form — the form may not have double opt-in enabled."
+    );
+  }
+} else {
+  section("3. Form subscriber — SKIPPED (no form id available)");
+}
+
+// ── 4. Broadcast create (draft) ──────────────────────────────────────────────────
+section("4. Broadcast create — POST /broadcasts (draft)");
+let broadcastId = null;
+{
+  findings.broadcastCreate.attempted = true;
+  // Only documented create fields, so the captured response shape is the real
+  // draft-create contract and not perturbed by an undocumented field.
+  const { ok, data } = await kit("POST", "/broadcasts", {
+    subject: "[SPIKE TEST] Kit free-tier verification — ignore",
+    content:
+      "<p>This is an automated verification of the Kit free Newsletter plan (issue #71). Safe to ignore/delete.</p>",
+    public: false,
+  });
+  const b = data?.broadcast ?? data;
+  broadcastId = b?.id ?? null;
+  findings.broadcastCreate.ok = ok;
+  findings.broadcastCreate.id = broadcastId;
+  findings.broadcastCreate.status = b?.status ?? null;
+  if (ok && broadcastId) {
+    console.log(`  ✓ broadcast draft created: id=${broadcastId} status=${b?.status ?? "?"}`);
+  } else {
+    console.log(
+      "  ⚠ broadcast create failed — see response above. This would block the whole integration."
+    );
+  }
+}
+
+// ── 5. Broadcast send (only with --send) ─────────────────────────────────────────
+let scheduledBroadcastId = null;
+if (DO_SEND) {
+  section("5. Broadcast send — POST /broadcasts with send_at (REAL SEND)");
+  // Per the primary-source contract (docs/research/newsletter-free-tier-comparison.md):
+  // POST /v4/broadcasts with a send_at ISO-8601 timestamp SCHEDULES the send — there is
+  // no separate "send" verb to prove. So we create a fresh broadcast with send_at a few
+  // minutes out; a non-2xx (esp. 402/403) is the plan restriction the spike hunts for.
+  // The offset gives a cancel window in the Kit dashboard before it actually goes out.
+  const sendAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+  findings.broadcastSend.attempted = true;
+  findings.broadcastSend.sendAt = sendAt;
+  console.log(`  Scheduling a send for ${sendAt} (cancel from the dashboard if needed).`);
+  const { ok, status, data } = await kit("POST", "/broadcasts", {
+    subject: "[SPIKE TEST] Kit free-tier scheduled send — ignore",
+    content: "<p>Automated free-tier send verification (issue #71). Safe to ignore/delete.</p>",
+    public: false,
+    send_at: sendAt,
+  });
+  scheduledBroadcastId = (data?.broadcast ?? data)?.id ?? null;
+  findings.broadcastSend.ok = ok;
+  // MailerLite-style hard plan block would surface as 402/403 with a plan message.
+  findings.broadcastSend.planRestricted = status === 402 || status === 403;
+  if (ok) {
+    console.log(`  ✓ Free plan ACCEPTED a scheduled send (status ${status}).`);
+    console.log(`    Watch ${TEST_EMAIL} at ${sendAt}, then confirm delivery.`);
+  } else if (findings.broadcastSend.planRestricted) {
+    console.log(
+      `  ✗ Send appears PLAN-RESTRICTED (status ${status}) — the free plan may forbid API sending.`
+    );
+    console.log("    This is the failure the spike was meant to catch. Document the fallback.");
+  } else {
+    console.log(
+      `  ⚠ Scheduled send returned ${status}. Inspect the body above — the shape may differ.`
+    );
+    console.log(`    (data: ${typeof data === "string" ? data : JSON.stringify(data)})`);
+  }
+} else {
+  section("5. Broadcast send — SKIPPED");
+  console.log(
+    DO_SEND ? "  (no broadcast id to send)" : "  Pass --send to perform a real scheduled send."
+  );
+}
+
+// ── 6. Cleanup (optional) ────────────────────────────────────────────────────────
+if (DO_CLEANUP && (broadcastId || scheduledBroadcastId)) {
+  section("6. Cleanup — DELETE /broadcasts/{id}");
+  // Delete the draft AND the scheduled broadcast — the latter would otherwise actually
+  // send at send_at, so cleanup doubles as the cancel for a --send run.
+  for (const id of [broadcastId, scheduledBroadcastId].filter(Boolean)) {
+    await kit("DELETE", `/broadcasts/${id}`);
+  }
+  console.log("  (Test subscriber left in place so you can inspect the confirmation email.)");
+} else if (DO_SEND && scheduledBroadcastId) {
+  console.log(
+    `\n  ⚠ A real send is scheduled (broadcast ${scheduledBroadcastId}). Cancel it in the Kit`
+  );
+  console.log("    dashboard, or re-run with --cleanup, if you do not want it to go out.");
+}
+
+// ── Summary + verdicts ───────────────────────────────────────────────────────────
+section("VERDICTS");
+findings.verdicts.authWorks = findings.auth.ok === true;
+findings.verdicts.broadcastCreateWorks = findings.broadcastCreate.ok === true;
+findings.verdicts.freeTierSend = DO_SEND
+  ? findings.broadcastSend.ok === true
+    ? "ALLOWED"
+    : findings.broadcastSend.planRestricted
+      ? "PLAN-RESTRICTED"
+      : "INCONCLUSIVE (see response)"
+  : "NOT TESTED (run with --send)";
+findings.verdicts.doubleOptIn = (() => {
+  const direct = findings.directSubscriber.doubleOptIn;
+  const form = findings.formSubscriber.doubleOptIn;
+  if (direct === true) return "DIRECT API path triggers double opt-in (no Form needed)";
+  if (form === true) return "FALLBACK required: route subscribers through a double-opt-in Kit Form";
+  if (direct === false && form !== true)
+    return "NO double opt-in observed on either path — investigate";
+  return "INCONCLUSIVE — confirm the inbox manually";
+})();
+
+console.log(`  Auth works ..................... ${findings.verdicts.authWorks ? "YES" : "NO"}`);
+console.log(
+  `  Broadcast create works ......... ${findings.verdicts.broadcastCreateWorks ? "YES" : "NO"}`
+);
+console.log(`  Free-tier API send ............. ${findings.verdicts.freeTierSend}`);
+console.log(`  Double opt-in .................. ${findings.verdicts.doubleOptIn}`);
+console.log("\n  NOTE: the API only reveals subscriber STATE. Whether the confirmation and");
+console.log(`  broadcast emails actually LAND is a human check — confirm both in ${TEST_EMAIL}.`);
+
+if (JSON_OUT) {
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(JSON_OUT, `${JSON.stringify(findings, null, 2)}\n`);
+  console.log(`\n  Findings written to ${JSON_OUT}`);
+}
+
+console.log(
+  "\nDone. Transcribe the shapes above into docs/research/kit-api-verification-spike.md."
+);

--- a/scripts/verify-kit-free-tier.mjs
+++ b/scripts/verify-kit-free-tier.mjs
@@ -225,12 +225,18 @@ let resolvedFormId = null;
 }
 
 if (resolvedFormId) {
-  // Distinct address from the direct test so double opt-in can actually be observed.
+  // The real double-opt-in flow is TWO calls: create the subscriber `inactive`, then
+  // associate it with a double-opt-in Form — the association is what makes Kit send the
+  // "confirm your subscription" email. A distinct address (plus-tag) keeps the direct
+  // test (step 1) from pre-activating it and masking the pending state.
   const formEmail = plusTag(TEST_EMAIL, "form");
-  section(`3. Form subscriber — POST /forms/${resolvedFormId}/subscribers { email_address }`);
+  section("3. Double opt-in flow — create inactive, then associate with the Form");
   console.log(`  Using a fresh address for this path: ${formEmail}`);
   findings.formSubscriber.attempted = true;
   findings.formSubscriber.formId = resolvedFormId;
+  // 3a. Create as inactive (no email yet).
+  await kit("POST", "/subscribers", { email_address: formEmail, state: "inactive" });
+  // 3b. Associate with the opt-in Form — this triggers the confirmation email.
   const { ok, data } = await kit("POST", `/forms/${resolvedFormId}/subscribers`, {
     email_address: formEmail,
   });
@@ -241,8 +247,8 @@ if (resolvedFormId) {
     console.log(`  → resulting state: ${state ?? "(not reported)"}`);
     console.log(
       doubleOptIn === true
-        ? `  ✓ state=inactive → double opt-in pending via the Form path. CONFIRM the email arrived in ${formEmail}.`
-        : "  ⚠ state is not 'inactive' via the Form — the form may not have double opt-in enabled."
+        ? `  ✓ state=inactive → double opt-in pending. CONFIRM the "confirm your subscription" email arrived in ${formEmail}.`
+        : "  ⚠ state is not 'inactive' — check the form has double opt-in enabled in the Kit UI."
     );
   }
 } else {
@@ -350,10 +356,11 @@ findings.verdicts.freeTierSend = DO_SEND
 findings.verdicts.doubleOptIn = (() => {
   const direct = findings.directSubscriber.doubleOptIn;
   const form = findings.formSubscriber.doubleOptIn;
-  if (direct === true) return "DIRECT API path triggers double opt-in (no Form needed)";
-  if (form === true) return "FALLBACK required: route subscribers through a double-opt-in Kit Form";
+  if (direct === true) return "DIRECT create triggers double opt-in (no Form needed)";
+  if (form === true)
+    return "WORKS via v4: create inactive → associate with a double-opt-in Form (confirm email sent)";
   if (direct === false && form !== true)
-    return "NO double opt-in observed on either path — investigate";
+    return "NO double opt-in observed — check the form has double opt-in enabled";
   return "INCONCLUSIVE — confirm the inbox manually";
 })();
 

--- a/src/app/(site)/uses/page.tsx
+++ b/src/app/(site)/uses/page.tsx
@@ -39,6 +39,11 @@ const HARDWARE = [
         description: "3840×2160, 60Hz, HDR10, 99% sRGB.",
       },
       {
+        name: 'Dell S2722QC · 27" 4K UHD',
+        description:
+          "Second display, rotated to portrait for long docs and code review. USB-C hub, 3840×2160, 60Hz.",
+      },
+      {
         name: "Aukey Webcam",
         description: "External webcam for calls, talks, and workshops.",
       },


### PR DESCRIPTION
Closes #71 (spike). Pre-build gate for the monthly-newsletter integration (PRD #70, ADR-0002).

## What this proves

All four assumptions the integration rests on were **verified live** against a real free-tier Kit account (`plan_type: free`, 10k-subscriber limit) on 2026-07-22:

| Acceptance criterion | Result |
|---|---|
| Broadcast create **+ send** via API on the free plan | ✅ `POST /v4/broadcasts` + `send_at` → `201 scheduled`, no plan block (no 402/403) |
| API-created subscriber triggers **double opt-in** | ✅ **works on v4** via a two-call flow (below) |
| Auth + subscriber-create + broadcast-create documented with request/response shapes | ✅ `docs/research/kit-api-verification-spike.md` |
| Kit env vars added, server-side only | ✅ `KIT_API_KEY`, `KIT_FORM_ID` (never `NEXT_PUBLIC_`) |

## Key finding — double opt-in IS achievable on v4

Not through a single call: the confirmation email is a **Form** behavior. The working flow (verified — two confirmation emails received) is:

1. `POST /v4/subscribers { email_address, state: "inactive" }`
2. `POST /v4/forms/{KIT_FORM_ID}/subscribers { email_address }` against a form with double opt-in enabled → Kit sends the *"Important: confirm your subscription"* email (button + Unsubscribe/Privacy footer); subscriber stays `inactive`.
3. Subscriber clicks confirm → `active`.

No v3 API (deprecated) and no embedded Kit form needed. This is the flow #74 should build.

## Open prerequisite (not an API limitation)

The test send **delivered but landed in spam**. Root cause: the domain is not authenticated for Kit — `GET /v4/account` reports the sending address `is_verified: true` but **`is_dmarc_configured: false`**. **Kit domain authentication (DKIM CNAMEs, SPF include, DMARC alignment) for `davideimola.dev` must be set up before issue #1 ships.**

## Contents

- `scripts/verify-kit-free-tier.mjs` — throwaway, dependency-free probe (key redacted; draft-by-default with gated `--send`/`--cleanup`). Re-runnable to re-verify.
- `docs/research/kit-api-verification-spike.md` — the v4 API contract + findings + verdicts.
- `.env.local.example` — the two Kit env vars, server-side only.
- `docs/adr/0002-*` + `docs/research/newsletter-free-tier-comparison.md` — the PRD #70 foundation the spike links to.
- `content(uses)`: unrelated small content addition (Dell portrait monitor) that rode along.

## What unblocks / stays gated

Auth, broadcast create+send, and the double-opt-in subscribe flow are proven → #72/#74/#75/#77 can proceed against this contract. The only remaining human prerequisite is Kit domain authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)