### PR TITLE
Newsletter: subscribe capability (#74)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -18,11 +18,12 @@ TURNSTILE_SECRET_KEY=
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=
 
 # Kit (formerly ConvertKit) — newsletter delivery (free "Newsletter" plan)
-# SERVER-SIDE ONLY. Never prefix with NEXT_PUBLIC_ — the API key must never reach
+# SERVER-SIDE ONLY. Never prefix with NEXT_PUBLIC_; the API key must never reach
 # the client bundle. Used by the subscribe server action and the digest skill.
 # v4 API key, sent as the X-Kit-Api-Key header. Create at Kit → Settings → Developer.
 KIT_API_KEY=
-# Id of the double-opt-in-enabled Kit Form subscribers are routed through, if the
-# direct POST /v4/subscribers path does not trigger Kit's confirmation email.
-# See docs/research/kit-api-verification-spike.md for which path the live test picked.
+# NUMERIC id of the double-opt-in-enabled Kit Form subscribers are routed through to
+# trigger the confirmation email (the two-call flow). Use the numeric id (e.g. 9713978),
+# NOT the embed uid from the form URL (e.g. 2484145147); the v4 API 404s on the uid.
+# See docs/research/kit-api-verification-spike.md.
 KIT_FORM_ID=

--- a/src/app/(site)/contact/ContactForm.tsx
+++ b/src/app/(site)/contact/ContactForm.tsx
@@ -2,6 +2,7 @@
 
 import { Turnstile } from "@marsidev/react-turnstile";
 import { useActionState, useEffect, useRef } from "react";
+import { StdoutPanel } from "../../../components/ui/StdoutPanel";
 import { sendContactEmail } from "../../actions/contact";
 
 const initialState = { status: "idle" as const };
@@ -18,12 +19,7 @@ export function ContactForm() {
 
   if (state.status === "success") {
     return (
-      <div className="border border-border rounded-sm overflow-hidden">
-        <div className="bg-bg-card border-b border-border px-4 py-2">
-          <span className="font-mono text-[10px] text-text-3 tracking-widest uppercase">
-            stdout
-          </span>
-        </div>
+      <StdoutPanel>
         <div className="px-4 py-8 flex flex-col gap-3">
           <p className="font-mono text-[13px]">
             <span className="text-accent">✓</span>{" "}
@@ -40,7 +36,7 @@ export function ContactForm() {
             ← send another
           </button>
         </div>
-      </div>
+      </StdoutPanel>
     );
   }
 

--- a/src/app/(site)/newsletter/confirmed/page.tsx
+++ b/src/app/(site)/newsletter/confirmed/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PageHero } from "../../../../components/ui/PageHero";
+import { StdoutPanel } from "../../../../components/ui/StdoutPanel";
+
+export const metadata: Metadata = {
+  title: "You're in",
+  description: "Your newsletter subscription is confirmed.",
+  // Post-confirmation landing: not meant to be indexed or shared. The Kit double-opt-in
+  // form must be configured to redirect here (https://davideimola.dev/newsletter/confirmed)
+  // after a subscriber clicks the confirmation link.
+  robots: { index: false, follow: false },
+};
+
+export default function NewsletterConfirmedPage() {
+  return (
+    <div className="max-w-[1024px] mx-auto px-4 sm:px-8 pt-24 pb-20">
+      <PageHero
+        command="cat ./welcome.md"
+        title="You're in"
+        description="Your subscription is confirmed. Thanks for joining, I'm glad to have you."
+      />
+
+      <StdoutPanel className="max-w-2xl">
+        <div className="px-4 py-8 flex flex-col gap-4">
+          <p className="font-mono text-[13px]">
+            <span className="text-accent">✓</span>{" "}
+            <span className="text-text-1">Subscription confirmed.</span>
+          </p>
+          <p className="font-sans text-[14px] text-text-2 leading-relaxed">
+            Once a month you'll get a short digest of what I published: new posts, upcoming talks,
+            and the occasional project. One email a month, no spam, unsubscribe anytime.
+          </p>
+          <div className="flex flex-wrap gap-4 pt-2">
+            <Link
+              href="/blog"
+              className="font-mono text-[12px] text-text-3 hover:text-accent transition-colors duration-150"
+            >
+              <span className="text-accent mr-1.5">→</span>read the blog
+            </Link>
+            <Link
+              href="/"
+              className="font-mono text-[12px] text-text-3 hover:text-accent transition-colors duration-150"
+            >
+              <span className="text-accent mr-1.5">→</span>back home
+            </Link>
+          </div>
+        </div>
+      </StdoutPanel>
+    </div>
+  );
+}

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { Resend } from "resend";
+import { isValidEmail } from "../../lib/email";
+import { verifyTurnstile } from "../../lib/turnstile";
 
 export interface ContactState {
   status: "idle" | "success" | "error";
@@ -33,16 +35,7 @@ export async function sendContactEmail(
   if (!turnstileToken) {
     return { status: "error", message: "Please complete the security check." };
   }
-  const turnstileRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      secret: process.env.TURNSTILE_SECRET_KEY,
-      response: turnstileToken,
-    }),
-  });
-  const turnstileData = (await turnstileRes.json()) as { success: boolean };
-  if (!turnstileData.success) {
+  if (!(await verifyTurnstile(turnstileToken))) {
     return { status: "error", message: "Security check failed. Please try again." };
   }
 
@@ -54,8 +47,7 @@ export async function sendContactEmail(
     return { status: "error", message: "All fields are required." };
   }
 
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(email)) {
+  if (!isValidEmail(email)) {
     return { status: "error", message: "Please enter a valid email address." };
   }
 

--- a/src/app/actions/subscribe.test.ts
+++ b/src/app/actions/subscribe.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { subscribe } from "./subscribe";
+
+const createSubscriberMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/kit", () => ({
+  createSubscriber: createSubscriberMock,
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const idle = { status: "idle" as const };
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fields: Record<string, string> = {
+    "cf-turnstile-response": "test-token",
+    email: "jane@example.com",
+    ...overrides,
+  };
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+beforeEach(() => {
+  createSubscriberMock.mockReset().mockResolvedValue({
+    id: 1,
+    email_address: "jane@example.com",
+    state: "inactive",
+  });
+  // Default: Turnstile verification passes.
+  fetchMock.mockReset().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+});
+
+describe("subscribe", () => {
+  it("silently accepts honeypot submissions without calling Kit", async () => {
+    const state = await subscribe(idle, makeFormData({ website: "spam.example" }));
+
+    expect(state.status).toBe("success");
+    expect(createSubscriberMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("errors when the Turnstile token is missing", async () => {
+    const fd = makeFormData();
+    fd.delete("cf-turnstile-response");
+
+    const state = await subscribe(idle, fd);
+
+    expect(state.status).toBe("error");
+    expect(createSubscriberMock).not.toHaveBeenCalled();
+  });
+
+  it("errors when Turnstile verification fails", async () => {
+    fetchMock.mockReset().mockResolvedValue({ ok: true, json: async () => ({ success: false }) });
+
+    const state = await subscribe(idle, makeFormData());
+
+    expect(state.status).toBe("error");
+    expect(createSubscriberMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid email without calling Kit", async () => {
+    const state = await subscribe(idle, makeFormData({ email: "not-an-email" }));
+
+    expect(state.status).toBe("error");
+    expect(createSubscriberMock).not.toHaveBeenCalled();
+  });
+
+  it("creates the subscriber and returns success for a valid email", async () => {
+    const state = await subscribe(idle, makeFormData());
+
+    expect(state.status).toBe("success");
+    expect(createSubscriberMock).toHaveBeenCalledWith("jane@example.com");
+  });
+
+  it("returns an error state when the Kit client throws", async () => {
+    createSubscriberMock.mockReset().mockRejectedValue(new Error("Kit API error (422)"));
+
+    const state = await subscribe(idle, makeFormData());
+
+    expect(state.status).toBe("error");
+  });
+});

--- a/src/app/actions/subscribe.ts
+++ b/src/app/actions/subscribe.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { isValidEmail } from "../../lib/email";
+import { createSubscriber } from "../../lib/kit";
+import { verifyTurnstile } from "../../lib/turnstile";
+
+export interface SubscribeState {
+  status: "idle" | "success" | "error";
+  message?: string;
+}
+
+export async function subscribe(
+  _prev: SubscribeState,
+  formData: FormData
+): Promise<SubscribeState> {
+  // Honeypot: bots fill this, humans don't. Pretend success so bots move on, and
+  // never call Kit for them.
+  const honeypot = formData.get("website")?.toString();
+  if (honeypot) {
+    return { status: "success" };
+  }
+
+  // Cloudflare Turnstile verification (shared with the contact action).
+  const turnstileToken = formData.get("cf-turnstile-response")?.toString();
+  if (!turnstileToken) {
+    return { status: "error", message: "Please complete the security check." };
+  }
+  if (!(await verifyTurnstile(turnstileToken))) {
+    return { status: "error", message: "Security check failed. Please try again." };
+  }
+
+  const email = formData.get("email")?.toString().trim();
+  if (!email || !isValidEmail(email)) {
+    return { status: "error", message: "Please enter a valid email address." };
+  }
+
+  try {
+    // Triggers Kit's double opt-in confirmation email; the subscriber stays pending
+    // until they click it, then lands on /newsletter/confirmed.
+    await createSubscriber(email);
+    return { status: "success" };
+  } catch {
+    return { status: "error", message: "Something went wrong. Please try again in a moment." };
+  }
+}

--- a/src/components/ui/StdoutPanel.tsx
+++ b/src/components/ui/StdoutPanel.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+interface StdoutPanelProps {
+  /** Content of the panel body. Provide your own padding wrapper. */
+  children: ReactNode;
+  /** Header label, uppercased in the title bar. Defaults to "stdout". */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * A bordered card with a terminal-style title bar, used for success/output states
+ * (contact + subscribe forms, the newsletter confirmation page). Keeps the "stdout"
+ * chrome in one place instead of repeated inline.
+ */
+export function StdoutPanel({ children, label = "stdout", className = "" }: StdoutPanelProps) {
+  return (
+    <div className={`border border-border rounded-sm overflow-hidden ${className}`}>
+      <div className="bg-bg-card border-b border-border px-4 py-2">
+        <span className="font-mono text-[10px] text-text-3 tracking-widest uppercase">{label}</span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/SubscribeForm.tsx
+++ b/src/components/ui/SubscribeForm.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Turnstile } from "@marsidev/react-turnstile";
+import { useActionState } from "react";
+import { subscribe } from "../../app/actions/subscribe";
+import { StdoutPanel } from "./StdoutPanel";
+
+const initialState = { status: "idle" as const };
+
+interface SubscribeFormProps {
+  /**
+   * `full`: the standalone form for the /newsletter page (label + widget + button).
+   * `compact`: a tight inline CTA for the home, sharing, and end-of-post placements.
+   */
+  mode?: "full" | "compact";
+  className?: string;
+}
+
+export function SubscribeForm({ mode = "full", className = "" }: SubscribeFormProps) {
+  const [state, action, pending] = useActionState(subscribe, initialState);
+  const compact = mode === "compact";
+
+  // Double opt-in: submitting only queues the confirmation email; the subscriber is
+  // not done until they click it. The success copy says so; it never claims "subscribed".
+  if (state.status === "success") {
+    return (
+      <StdoutPanel className={className}>
+        <div className="px-4 py-6 flex flex-col gap-2">
+          <p className="font-mono text-[13px]">
+            <span className="text-accent">✓</span>{" "}
+            <span className="text-text-1">Almost there.</span>
+          </p>
+          <p className="font-sans text-[13px] text-text-3">
+            Check your inbox and click the confirmation link to finish subscribing.
+          </p>
+        </div>
+      </StdoutPanel>
+    );
+  }
+
+  return (
+    <form action={action} className={`flex flex-col ${compact ? "gap-3" : "gap-5"} ${className}`}>
+      {/* Honeypot: hidden from humans, filled by bots */}
+      <div
+        aria-hidden="true"
+        tabIndex={-1}
+        style={{ position: "absolute", left: "-9999px", opacity: 0, pointerEvents: "none" }}
+      >
+        <label htmlFor={`website-${mode}`}>Website</label>
+        <input id={`website-${mode}`} name="website" type="text" autoComplete="off" tabIndex={-1} />
+      </div>
+
+      {/* Email */}
+      <div className="flex flex-col gap-1.5">
+        {!compact && (
+          <label
+            htmlFor={`email-${mode}`}
+            className="font-mono text-[11px] text-text-3 tracking-widest uppercase"
+          >
+            Email
+          </label>
+        )}
+        <input
+          id={`email-${mode}`}
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          placeholder="your@email.com"
+          aria-label={compact ? "Email address" : undefined}
+          className="bg-bg-card border border-border rounded-sm px-3 py-2.5 font-mono text-[13px] text-text-1 placeholder:text-text-3 outline-none focus:border-accent transition-colors duration-150"
+        />
+      </div>
+
+      {/* Turnstile */}
+      <Turnstile
+        siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ""}
+        options={{ theme: "dark", size: compact ? "flexible" : "normal" }}
+      />
+
+      {/* Error */}
+      {state.status === "error" && (
+        <p className="font-mono text-[12px] text-accent">
+          <span className="mr-2">✗</span>
+          {state.message}
+        </p>
+      )}
+
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={pending}
+        className="self-start font-mono text-[12px] text-text-1 bg-bg-card border border-border rounded-sm px-4 py-2.5 cursor-pointer hover:border-border-hover hover:text-accent transition-[border-color,color] duration-150 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+      >
+        <span className="text-accent">❯</span>
+        {pending ? "subscribing..." : "subscribe"}
+      </button>
+    </form>
+  );
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,7 @@
+// Minimal email shape check shared by the contact and subscribe server actions.
+// Deliberately loose: a full RFC check is not worth it; the provider validates for real.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email);
+}

--- a/src/lib/kit.test.ts
+++ b/src/lib/kit.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSubscriber } from "./kit";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+// A successful Kit response for both calls in the two-call double-opt-in flow.
+function okSubscriber(state = "inactive") {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      subscriber: { id: 123, email_address: "jane@example.com", state },
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.stubEnv("KIT_API_KEY", "test-key");
+  vi.stubEnv("KIT_FORM_ID", "999");
+  fetchMock.mockReset().mockResolvedValue(okSubscriber());
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("createSubscriber", () => {
+  it("creates the subscriber as inactive, then associates it with the opt-in form", async () => {
+    await createSubscriber("jane@example.com");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // 1. create as inactive (no confirmation email yet)
+    const [createUrl, createInit] = fetchMock.mock.calls[0];
+    expect(createUrl).toBe("https://api.kit.com/v4/subscribers");
+    expect(createInit.method).toBe("POST");
+    expect(createInit.headers["X-Kit-Api-Key"]).toBe("test-key");
+    expect(JSON.parse(createInit.body)).toEqual({
+      email_address: "jane@example.com",
+      state: "inactive",
+    });
+
+    // 2. associate with the double-opt-in form → this is what sends the confirm email
+    const [formUrl, formInit] = fetchMock.mock.calls[1];
+    expect(formUrl).toBe("https://api.kit.com/v4/forms/999/subscribers");
+    expect(formInit.method).toBe("POST");
+    expect(formInit.headers["X-Kit-Api-Key"]).toBe("test-key");
+    expect(JSON.parse(formInit.body)).toEqual({ email_address: "jane@example.com" });
+  });
+
+  it("returns the created subscriber", async () => {
+    const subscriber = await createSubscriber("jane@example.com");
+
+    expect(subscriber).toMatchObject({ email_address: "jane@example.com", state: "inactive" });
+  });
+
+  it("surfaces an API error from the create call as a thrown error", async () => {
+    fetchMock.mockReset().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ errors: ["Email address is invalid"] }),
+    });
+
+    await expect(createSubscriber("bad")).rejects.toThrow();
+    // The form association must not run if the create failed.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an API error from the form-association call as a thrown error", async () => {
+    fetchMock
+      .mockReset()
+      .mockResolvedValueOnce(okSubscriber())
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ errors: ["Not Found"] }),
+      });
+
+    await expect(createSubscriber("jane@example.com")).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a clear error when Kit env vars are missing", async () => {
+    vi.stubEnv("KIT_API_KEY", "");
+    vi.stubEnv("KIT_FORM_ID", "");
+
+    await expect(createSubscriber("jane@example.com")).rejects.toThrow(/KIT_/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/kit.ts
+++ b/src/lib/kit.ts
@@ -1,0 +1,64 @@
+// Thin, typed wrapper over the Kit (formerly ConvertKit) v4 REST API. The only place
+// in the app that talks to Kit. Server-side only: it reads KIT_API_KEY, which must
+// never reach the client bundle.
+//
+// The double opt-in flow is deliberately TWO calls (verified by the #71 spike, see
+// docs/research/kit-api-verification-spike.md): the v4 API has no single-call
+// double-opt-in. Creating a subscriber alone yields an `active` (or silently
+// `inactive`) record with no confirmation email; the confirmation email is a *form*
+// behaviour. So we create the subscriber `inactive`, then associate it with a
+// double-opt-in-enabled Kit Form, which is what makes Kit send the confirmation email.
+
+const KIT_BASE_URL = "https://api.kit.com/v4";
+
+export interface KitSubscriber {
+  id: number;
+  email_address: string;
+  state: string;
+}
+
+/**
+ * Subscribe an email via Kit's double opt-in flow. Returns the created (pending)
+ * subscriber. Throws if the Kit env is missing or the API rejects either call; the
+ * caller (subscribe action) turns that into an error state.
+ */
+export async function createSubscriber(email: string): Promise<KitSubscriber> {
+  const apiKey = process.env.KIT_API_KEY;
+  // Must be the NUMERIC form id (e.g. 9713978), not the embed uid from the form URL;
+  // the v4 forms endpoint 404s on the uid (see the #71 spike).
+  const formId = process.env.KIT_FORM_ID;
+  if (!apiKey || !formId) {
+    throw new Error("Missing KIT_API_KEY or KIT_FORM_ID environment variables.");
+  }
+
+  // 1. Create the subscriber as inactive (no email yet).
+  const created = await kitPost("/subscribers", apiKey, {
+    email_address: email,
+    state: "inactive",
+  });
+
+  // 2. Associate with the double-opt-in form → triggers Kit's confirmation email.
+  await kitPost(`/forms/${formId}/subscribers`, apiKey, { email_address: email });
+
+  return (created.subscriber ?? created) as KitSubscriber;
+}
+
+async function kitPost(
+  path: string,
+  apiKey: string,
+  body: Record<string, unknown>
+): Promise<{ subscriber?: KitSubscriber }> {
+  const res = await fetch(`${KIT_BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "X-Kit-Api-Key": apiKey,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Kit API error (${res.status}) for POST ${path}`);
+  }
+  return res.json();
+}

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,19 @@
+// Cloudflare Turnstile server-side verification, shared by the contact and subscribe
+// actions. Callers keep their own "token missing" guard (so they can word that case
+// their own way) and call this only to verify a present token.
+
+const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/** Verify a Turnstile token against Cloudflare. Returns true only on a confirmed pass. */
+export async function verifyTurnstile(token: string): Promise<boolean> {
+  const res = await fetch(SITEVERIFY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      secret: process.env.TURNSTILE_SECRET_KEY,
+      response: token,
+    }),
+  });
+  const data = (await res.json()) as { success: boolean };
+  return data.success === true;
+}

--- a/src/stories/StdoutPanel.stories.tsx
+++ b/src/stories/StdoutPanel.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StdoutPanel } from "../components/ui/StdoutPanel";
+
+const meta: Meta<typeof StdoutPanel> = {
+  title: "UI/StdoutPanel",
+  component: StdoutPanel,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#080807" }],
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof StdoutPanel>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[420px] max-w-full">
+      <StdoutPanel>
+        <div className="px-4 py-6 flex flex-col gap-2">
+          <p className="font-mono text-[13px]">
+            <span className="text-accent">✓</span>{" "}
+            <span className="text-text-1">Almost there.</span>
+          </p>
+          <p className="font-sans text-[13px] text-text-3">
+            Check your inbox and click the confirmation link to finish subscribing.
+          </p>
+        </div>
+      </StdoutPanel>
+    </div>
+  ),
+};
+
+export const CustomLabel: Story = {
+  render: () => (
+    <div className="w-[420px] max-w-full">
+      <StdoutPanel label="stderr">
+        <div className="px-4 py-6">
+          <p className="font-mono text-[13px] text-accent">✗ Something went wrong.</p>
+        </div>
+      </StdoutPanel>
+    </div>
+  ),
+};

--- a/src/stories/SubscribeForm.stories.tsx
+++ b/src/stories/SubscribeForm.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SubscribeForm } from "../components/ui/SubscribeForm";
+
+const meta: Meta<typeof SubscribeForm> = {
+  title: "UI/SubscribeForm",
+  component: SubscribeForm,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#080807" }],
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    mode: {
+      control: "radio",
+      options: ["full", "compact"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SubscribeForm>;
+
+export const Full: Story = {
+  args: { mode: "full" },
+  render: (args) => (
+    <div className="w-[420px] max-w-full">
+      <SubscribeForm {...args} />
+    </div>
+  ),
+};
+
+export const Compact: Story = {
+  args: { mode: "compact" },
+  render: (args) => (
+    <div className="w-[320px] max-w-full">
+      <SubscribeForm {...args} />
+    </div>
+  ),
+};


### PR DESCRIPTION
Closes #74. Implements the newsletter subscribe capability on the double-opt-in flow verified by the #71 spike.

## What's in it

- **`lib/kit.ts`** — Kit v4 client `createSubscriber`, the spike-verified **two-call** double-opt-in flow: `POST /v4/subscribers` with `state:"inactive"`, then `POST /v4/forms/{KIT_FORM_ID}/subscribers` (which triggers Kit's *"confirm your subscription"* email). Server-side only; throws on API error. Fully covered by `kit.test.ts` (endpoint/headers/body + errors from either call + missing-env).
- **`lib/turnstile.ts` + `lib/email.ts`** — shared Turnstile verification and email check, prefactored out of the contact action (the issue's optional prefactor). Both actions consume them; contact tests stay green.
- **`actions/subscribe.ts`** — server action mirroring the contact action: honeypot short-circuit (never calls Kit), Turnstile, email validation, then `createSubscriber`. Covered by `subscribe.test.ts` (mirrors the contact-action tests).
- **`ui/SubscribeForm.tsx`** — client form, `full` + `compact` modes. Double-opt-in-correct success copy ("check your inbox to confirm") — never claims "subscribed". Storybook story for both modes.
- **`ui/StdoutPanel.tsx`** — shared terminal-style output card, extracted to remove markup triplicated across the contact form, subscribe form, and confirmation page. Storybook story.
- **`(site)/newsletter/confirmed`** — branded "you're in" landing (`noindex`) for Kit's post-confirmation redirect.

## Acceptance criteria

- [x] Valid email → `createSubscriber` → success state; subscriber gets the double opt-in email (two-call flow).
- [x] Honeypot silently accepted without calling Kit; missing/failed Turnstile and invalid email → error state. Tests mirror the contact-action tests.
- [x] `createSubscriber` covered by mocked-fetch tests (endpoint/headers/body; API errors surfaced).
- [x] `SubscribeForm` (full mode) has a Storybook story and is responsive.
- [x] Branded post-confirmation landing page exists; **Kit redirect to it is a manual dashboard step** (see below).

## Manual Kit configuration required (not code)

1. `KIT_FORM_ID` = the **numeric** form id (e.g. `9713978`), NOT the embed uid — the v4 API 404s on the uid.
2. The target form must have **double opt-in enabled**.
3. Set the form's **post-confirmation redirect** to `https://davideimola.dev/newsletter/confirmed`.

## Scope notes

Placement of the form on Home / Sharing / end-of-post / the full `/newsletter` page is **#76**; the `/newsletter` archive + `[slug]` pages are **#72**. This PR builds the capability + component (via Storybook) + confirmation landing only.

## Validation

`tsc --noEmit` clean · Biome clean · 164 tests pass (added `kit.test.ts`, `subscribe.test.ts`, 2 stories). Two-axis code review (Standards + Spec) run and its findings applied (em dash removed, `isValidEmail` + `StdoutPanel` extracted, KIT_FORM_ID id-vs-uid documented in code + env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)