### PR TITLE
Newsletter: on-site archive (frozen issue model + loader + pages) (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Every page uses a terminal-style command as its hero label. Follow this pattern:
 - Now: `❯ cat ./now.md`
 - Uses: `❯ cat ./uses.md`
 - Contact: `❯ ping davideimola.dev`
+- Newsletter: `❯ ls ./newsletter` (archive index + subscribe form); single issue `/newsletter/[slug]` uses `❯ cat` in a Breadcrumb; post-confirmation landing `/newsletter/confirmed` uses `❯ cat ./welcome.md`
 - Links: multi-command terminal session (`❯ whoami`, `❯ ls -t ./blog | head -n 1`, `❯ ls ./talks --upcoming`, `❯ cal --book`, `❯ ls ./schrodinger-hat`) — standalone link-in-bio page living outside the `(site)` route group, so it renders without NavBar/Footer even when reached via rewrite; `links.davideimola.dev` serves this page directly via a host-based rewrite in `next.config.ts` (deep paths on the subdomain redirect to the main site); revalidates daily (ISR) so dynamic blocks stay fresh
 - Terminal: `❯ ssh guest@davideimola.dev` — a REAL interactive shell at `/terminal`: the visitor types commands and the site answers. Pure command engine in `src/lib/terminal.ts` (unit-tested, no React/browser APIs), client component `InteractiveTerminal` in `src/components/sections/`, data (posts/talks/projects) injected by the server page. Includes easter eggs (`sudo`, `rm`, `nmap`, `argus`, `vim`, `ssh`, `ping`); an `ask` AI command (Gemini free tier) is planned but not built. Linked from footer and 404; revalidates daily (ISR)
 
@@ -159,7 +160,7 @@ Only add `"use client"` when the component needs interactivity (event handlers, 
 
 ## What NOT to do
 
-- Do NOT add newsletter or email subscription UI
+- The newsletter is now built per ADR-0002 (hybrid model, Kit delivery, in-repo content): the `/newsletter` archive + subscribe form, the `SubscribeForm` component, the subscribe action, and the Kit client all exist. Do NOT reintroduce a "no newsletter UI" assumption. (Historically this repo banned newsletter UI; ADR-0002 lifted that.)
 - Do NOT use tRPC — use Server Actions for mutations
 - Do NOT set `ignoreBuildErrors: true` in `next.config.ts`
 - Do NOT use npm or yarn — always pnpm

--- a/src/app/(site)/newsletter/[slug]/page.tsx
+++ b/src/app/(site)/newsletter/[slug]/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import type React from "react";
+import rehypePrism from "rehype-prism-plus";
+import rehypeSlug from "rehype-slug";
+import remarkGfm from "remark-gfm";
+import remarkGithubAlerts from "remark-github-alerts";
+import { Breadcrumb } from "../../../../components/ui/Breadcrumb";
+import { CodeBlock } from "../../../../components/ui/CodeBlock";
+import { JsonLd } from "../../../../components/ui/JsonLd";
+import { SubscribeForm } from "../../../../components/ui/SubscribeForm";
+import { formatDate } from "../../../../lib/dates";
+import { getAllIssues, getIssueBySlug } from "../../../../lib/newsletter";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return getAllIssues().map((issue) => ({ slug: issue.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const issue = getIssueBySlug(slug);
+  if (!issue) return {};
+
+  const ogImageUrl = `https://davideimola.dev/og?title=${encodeURIComponent(issue.subject)}&category=newsletter`;
+
+  return {
+    title: issue.subject,
+    description: issue.previewText,
+    alternates: { canonical: `https://davideimola.dev/newsletter/${slug}` },
+    openGraph: {
+      title: issue.subject,
+      description: issue.previewText,
+      url: `https://davideimola.dev/newsletter/${slug}`,
+      type: "article",
+      publishedTime: issue.date,
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: issue.subject }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: issue.subject,
+      description: issue.previewText,
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export default async function NewsletterIssuePage({ params }: Props) {
+  const { slug } = await params;
+  const issue = getIssueBySlug(slug);
+  if (!issue) notFound();
+
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: issue.subject,
+    description: issue.previewText,
+    datePublished: issue.date,
+    url: `https://davideimola.dev/newsletter/${slug}`,
+    author: { "@type": "Person", name: "Davide Imola", url: "https://davideimola.dev" },
+  };
+
+  return (
+    <>
+      <JsonLd data={schema} />
+      <div className="max-w-[768px] mx-auto px-4 sm:px-8 pt-24 pb-20">
+        <Breadcrumb
+          command="cat"
+          items={[{ label: "newsletter", href: "/newsletter" }, { label: `${slug}.mdx` }]}
+          className="mb-10"
+        />
+
+        <article>
+          <header className="mb-10">
+            <p className="font-mono text-[12px] text-text-3 mb-3">
+              Issue #{issue.issue} · {formatDate(issue.date)}
+            </p>
+            <h1 className="font-mono text-[26px] sm:text-[32px] font-bold text-text-1 tracking-[-0.03em] leading-tight">
+              {issue.subject}
+            </h1>
+          </header>
+
+          <div className="prose prose-lg max-w-none">
+            <MDXRemote
+              source={issue.content}
+              options={{
+                mdxOptions: {
+                  remarkPlugins: [remarkGfm, remarkGithubAlerts],
+                  rehypePlugins: [rehypeSlug, [rehypePrism, { ignoreMissing: true }]],
+                },
+              }}
+              components={{ pre: CodeBlock as React.ComponentType<object> }}
+            />
+          </div>
+        </article>
+
+        {/* Subscribe CTA */}
+        <div className="mt-14 pt-10 border-t border-border">
+          <p className="font-mono text-[11px] text-text-3 tracking-widest uppercase mb-4">
+            Get the next issue
+          </p>
+          <div className="max-w-md">
+            <SubscribeForm mode="compact" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(site)/newsletter/page.tsx
+++ b/src/app/(site)/newsletter/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PageHero } from "../../../components/ui/PageHero";
+import { SubscribeForm } from "../../../components/ui/SubscribeForm";
+import { formatDate } from "../../../lib/dates";
+import { getAllIssues } from "../../../lib/newsletter";
+
+export const metadata: Metadata = {
+  title: "Newsletter",
+  description: "One email a month: new posts, upcoming talks, and the occasional project. No spam.",
+  openGraph: {
+    title: "Newsletter · Davide Imola",
+    description:
+      "One email a month: new posts, upcoming talks, and the occasional project. No spam.",
+    url: "https://davideimola.dev/newsletter",
+    images: [
+      {
+        url: "https://davideimola.dev/og?title=Newsletter&category=newsletter",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
+
+export default function NewsletterPage() {
+  const issues = getAllIssues();
+
+  return (
+    <div className="max-w-[1024px] mx-auto px-4 sm:px-8 pt-24 pb-20">
+      <PageHero
+        command="ls ./newsletter"
+        title="Newsletter"
+        description="A short monthly digest of what I published: new posts, upcoming talks, and the occasional project. One email a month, no spam, unsubscribe anytime."
+      />
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-12">
+        {/* Archive */}
+        <section>
+          <h2 className="font-mono text-[11px] text-text-3 tracking-widest uppercase mb-6">
+            Past issues
+          </h2>
+          {issues.length === 0 ? (
+            <p className="font-sans text-[14px] text-text-3">
+              No issues yet. Subscribe and the first one will land in your inbox.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-3">
+              {issues.map((issue) => (
+                <li key={issue.slug}>
+                  <Link
+                    href={`/newsletter/${issue.slug}`}
+                    className="group block border border-border rounded-sm px-5 py-4 hover:border-border-hover transition-colors duration-150"
+                  >
+                    <span className="font-mono text-[11px] text-text-3">
+                      #{issue.issue} · {formatDate(issue.date)}
+                    </span>
+                    <h3 className="font-mono text-[15px] text-text-1 group-hover:text-accent transition-colors duration-150 mt-1 mb-1.5">
+                      {issue.subject}
+                    </h3>
+                    <p className="font-sans text-[13px] text-text-3 leading-relaxed">
+                      {issue.previewText}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Subscribe */}
+        <aside className="lg:sticky lg:top-[88px] self-start">
+          <h2 className="font-mono text-[11px] text-text-3 tracking-widest uppercase mb-4">
+            Subscribe
+          </h2>
+          <SubscribeForm mode="full" />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getAllPosts } from "../lib/content";
+import { getAllIssues } from "../lib/newsletter";
 
 const BASE_URL = "https://davideimola.dev";
 
@@ -13,6 +14,7 @@ const STATIC_ROUTES = [
   { url: `${BASE_URL}/uses`, priority: 0.6, changeFrequency: "monthly" as const },
   { url: `${BASE_URL}/brand`, priority: 0.4, changeFrequency: "yearly" as const },
   { url: `${BASE_URL}/contact`, priority: 0.5, changeFrequency: "yearly" as const },
+  { url: `${BASE_URL}/newsletter`, priority: 0.6, changeFrequency: "monthly" as const },
   { url: `${BASE_URL}/links`, priority: 0.5, changeFrequency: "monthly" as const },
   { url: `${BASE_URL}/terminal`, priority: 0.4, changeFrequency: "monthly" as const },
 ];
@@ -25,5 +27,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "monthly" as const,
   }));
 
-  return [...STATIC_ROUTES, ...posts];
+  const issues = getAllIssues().map((issue) => ({
+    url: `${BASE_URL}/newsletter/${issue.slug}`,
+    lastModified: new Date(issue.date),
+    priority: 0.5,
+    changeFrequency: "yearly" as const,
+  }));
+
+  return [...STATIC_ROUTES, ...posts, ...issues];
 }

--- a/src/content/newsletter/2026-07.mdx
+++ b/src/content/newsletter/2026-07.mdx
@@ -1,0 +1,29 @@
+---
+issue: 1
+subject: "July 2026: shipping quietly, writing loudly"
+previewText: "A verification spike that saved a bad assumption, two posts on tools and trust, and where to catch me this autumn."
+sendDate: "2026-07-28"
+---
+
+Welcome to the first issue. If you subscribed, thank you: you are reading the thing I was most nervous to start. The plan is simple and honest. Once a month I send a short digest of what I actually published: new posts, upcoming talks, and the occasional project. No filler, no growth hacks, and if a month is quiet I skip it rather than pad it.
+
+This month was less about shipping features and more about checking my own assumptions before building on them. That turned out to be the theme.
+
+## New on the blog
+
+A couple of pieces I published this month, both circling the same idea: tools are only as good as the trust you can actually justify in them.
+
+- [AI will not secure your codebase](/blog/ai-will-not-secure-your-codebase): why "we added an AI reviewer" is not a security strategy, and what it takes to make one useful instead of decorative.
+- [I built a tool I don't use](/blog/i-built-a-tool-i-dont-use): a small retrospective on shipping something technically fine that solved a problem I did not really have.
+
+## Where to catch me
+
+I will be speaking at **reactjsday 2026** later this year. If you are coming, find me: I am always happier talking in a hallway than on a stage.
+
+More dates may land before the next issue. When they do, they will show up here first.
+
+## That's it
+
+That is the whole issue. Short on purpose. If something here was useful, the best thing you can do is reply and tell me what you would want more of. I read every reply.
+
+See you next month.

--- a/src/lib/newsletter.test.ts
+++ b/src/lib/newsletter.test.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getAllIssues, getIssueBySlug, getLatestIssue } from "./newsletter";
+
+vi.mock("node:fs", () => ({
+  default: {
+    readdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    existsSync: vi.fn(),
+  },
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+const mockFs = vi.mocked(fs);
+
+function issueMdx(fields: {
+  issue: number;
+  subject: string;
+  previewText: string;
+  sendDate: string;
+  draft?: boolean;
+}): string {
+  return [
+    "---",
+    `issue: ${fields.issue}`,
+    `subject: "${fields.subject}"`,
+    `previewText: "${fields.previewText}"`,
+    `sendDate: "${fields.sendDate}"`,
+    ...(fields.draft !== undefined ? [`draft: ${fields.draft}`] : []),
+    "---",
+    "",
+    "## Intro",
+    "",
+    "Issue body.",
+  ].join("\n");
+}
+
+// Two published issues (JULY newest) plus a draft.
+const JULY = issueMdx({
+  issue: 2,
+  subject: "July digest",
+  previewText: "What I shipped in July.",
+  sendDate: "2026-07-28",
+});
+const JUNE = issueMdx({
+  issue: 1,
+  subject: "June digest",
+  previewText: "The first issue.",
+  sendDate: "2026-06-28",
+});
+const DRAFT = issueMdx({
+  issue: 3,
+  subject: "August draft",
+  previewText: "Not sent yet.",
+  sendDate: "2026-08-28",
+  draft: true,
+});
+
+function setupIssues(files = ["2026-07.mdx", "2026-06.mdx"]) {
+  mockFs.existsSync.mockReturnValue(true);
+  mockFs.readdirSync.mockReturnValue(files as never);
+  mockFs.readFileSync.mockImplementation((filePath: unknown) => {
+    const p = String(filePath);
+    if (p.includes("2026-07")) return JULY;
+    if (p.includes("2026-06")) return JUNE;
+    if (p.includes("2026-08")) return DRAFT;
+    return "";
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("NODE_ENV", "production");
+  setupIssues();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("getAllIssues", () => {
+  it("returns issues newest-first", () => {
+    const issues = getAllIssues();
+    expect(issues.map((i) => i.slug)).toEqual(["2026-07", "2026-06"]);
+  });
+
+  it("parses frontmatter into the NewsletterIssue shape", () => {
+    const [july] = getAllIssues();
+    expect(july).toMatchObject({
+      slug: "2026-07",
+      issue: 2,
+      subject: "July digest",
+      previewText: "What I shipped in July.",
+      date: "2026-07-28",
+    });
+    expect(july.content).toContain("Issue body.");
+  });
+
+  it("returns an empty array when the directory does not exist", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    expect(getAllIssues()).toEqual([]);
+  });
+
+  it("hides drafts in production", () => {
+    setupIssues(["2026-07.mdx", "2026-06.mdx", "2026-08.mdx"]);
+    const issues = getAllIssues();
+    expect(issues.some((i) => i.slug === "2026-08")).toBe(false);
+    expect(issues).toHaveLength(2);
+  });
+
+  it("includes drafts in development", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    setupIssues(["2026-07.mdx", "2026-06.mdx", "2026-08.mdx"]);
+    const issues = getAllIssues();
+    expect(issues.some((i) => i.slug === "2026-08")).toBe(true);
+    expect(issues).toHaveLength(3);
+  });
+});
+
+describe("getIssueBySlug", () => {
+  it("returns the issue for a known slug", () => {
+    expect(getIssueBySlug("2026-07")?.subject).toBe("July digest");
+  });
+
+  it("returns null for a missing file", () => {
+    mockFs.existsSync.mockReturnValue(false);
+    expect(getIssueBySlug("nope")).toBeNull();
+  });
+
+  it("returns null for a draft issue in production", () => {
+    mockFs.readFileSync.mockReturnValue(DRAFT);
+    expect(getIssueBySlug("2026-08")).toBeNull();
+  });
+
+  it("returns a draft issue in development", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    mockFs.readFileSync.mockReturnValue(DRAFT);
+    expect(getIssueBySlug("2026-08")).not.toBeNull();
+  });
+});
+
+describe("getLatestIssue", () => {
+  it("returns the newest published issue", () => {
+    expect(getLatestIssue()?.slug).toBe("2026-07");
+  });
+
+  it("returns null when there are no issues", () => {
+    mockFs.readdirSync.mockReturnValue([] as never);
+    expect(getLatestIssue()).toBeNull();
+  });
+});

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import matter from "gray-matter";
+
+// A frozen newsletter issue: one .mdx file per issue in src/content/newsletter,
+// snapshotted at generation time ("photograph, not mirror", per ADR-0002). The same
+// file is the single source for both the sent email and this on-site archive.
+export interface NewsletterIssue {
+  slug: string; // filename without .mdx, e.g. "2026-07"
+  issue: number; // sequential issue number
+  subject: string; // issue title / email subject
+  previewText: string; // short preview / description
+  date: string; // send date (ISO), mapped from sendDate
+  draft?: boolean;
+  content: string; // MDX body
+}
+
+const NEWSLETTER_DIR = path.join(process.cwd(), "src/content/newsletter");
+
+function parseIssue(slug: string): NewsletterIssue {
+  const raw = fs.readFileSync(path.join(NEWSLETTER_DIR, `${slug}.mdx`), "utf-8");
+  const { data, content } = matter(raw);
+  return {
+    slug,
+    issue: data.issue ?? 0,
+    subject: data.subject ?? "",
+    previewText: data.previewText ?? "",
+    date: data.sendDate,
+    draft: data.draft ?? false,
+    content,
+  };
+}
+
+export function getAllIssues(): NewsletterIssue[] {
+  const isDev = process.env.NODE_ENV === "development";
+  if (!fs.existsSync(NEWSLETTER_DIR)) return [];
+  return fs
+    .readdirSync(NEWSLETTER_DIR)
+    .filter((f) => f.endsWith(".mdx"))
+    .map((f) => parseIssue(f.replace(".mdx", "")))
+    .filter((i) => isDev || !i.draft)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+export function getIssueBySlug(slug: string): NewsletterIssue | null {
+  const isDev = process.env.NODE_ENV === "development";
+  const filePath = path.join(NEWSLETTER_DIR, `${slug}.mdx`);
+  if (!fs.existsSync(filePath)) return null;
+  const issue = parseIssue(slug);
+  if (!isDev && issue.draft) return null;
+  return issue;
+}
+
+export function getLatestIssue(): NewsletterIssue | null {
+  return getAllIssues()[0] ?? null;
+}


### PR DESCRIPTION
Closes #72. Adds the on-site newsletter archive: frozen `.mdx` issues, a loader, and the `/newsletter` + `/newsletter/[slug]` pages. Builds on the merged #74 subscribe capability (the `/newsletter` page hosts the full `SubscribeForm`).

## What's in it

- **`lib/newsletter.ts`** — frozen-issue loader mirroring the blog loader. `NewsletterIssue` (slug, issue, subject, previewText, date, draft, content); `getAllIssues` / `getIssueBySlug` / `getLatestIssue`; reads `src/content/newsletter/*.mdx`; drafts hidden outside dev; sorted newest-first. Covered by `newsletter.test.ts` (mirrors the blog content-loader tests: sort, parse shape, empty dir, draft prod/dev for list + by-slug).
- **`content/newsletter/2026-07.mdx`** — hand-written sample issue ("photograph, not mirror", per ADR-0002) so both pages render.
- **`(site)/newsletter`** — archive index (newest-first, each row links to its issue) + the full `SubscribeForm`, terminal-command hero (`❯ ls ./newsletter`), metadata + OG. Responsive two-column (stacks on mobile).
- **`(site)/newsletter/[slug]`** — single issue rendered from its frozen `.mdx` via the site's MDX stack (`next-mdx-remote/rsc` + the blog's remark/rehype plugins + `CodeBlock`), long-form `prose` styling, `generateStaticParams` + full metadata/OG/JSON-LD, and a compact subscribe CTA.
- **`sitemap.ts`** — include `/newsletter` and each issue.
- **`CLAUDE.md`** — document the `/newsletter` terminal command; resolve the now-stale "no newsletter UI" ban (lifted by ADR-0002).

## Acceptance criteria

- [x] `/newsletter` lists past issues newest-first and links to each.
- [x] `/newsletter/[slug]` renders a frozen `.mdx` via the site's MDX stack, long-form styled.
- [x] Loader exposes get-all / get-by-slug / get-latest, hides drafts outside dev; tests mirror the blog loader tests.
- [x] A sample issue exists so both pages render.
- [x] Issue pages expose title/description/OG metadata; `/newsletter` uses a terminal-command hero consistent with the site.
- [x] All surfaces responsive.

## Validation

`tsc --noEmit` clean · Biome clean · 175 tests pass · production build renders `/newsletter`, `/newsletter/2026-07`, and `/newsletter/confirmed`. Two-axis code review run and its findings applied.

## Scope notes

Compact-CTA placements on home / sharing / end-of-post + the footer link are **#76**. The harvest engine that will auto-assemble issues is **#73**; the drafting skill is **#77**. This PR is the archive + reader surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)