### PR TITLE
Newsletter: site-wide subscribe placements (#76)

### DIFF
--- a/src/app/(site)/blog/[slug]/page.tsx
+++ b/src/app/(site)/blog/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { PostNavigation } from "../../../../components/ui/PostNavigation";
 import { ReadingProgress } from "../../../../components/ui/ReadingProgress";
 import { RelatedPosts } from "../../../../components/ui/RelatedPosts";
 import { ShareButtons } from "../../../../components/ui/ShareButtons";
+import { SubscribeCTA } from "../../../../components/ui/SubscribeCTA";
 import { TableOfContents } from "../../../../components/ui/TableOfContents";
 import {
   extractToc,
@@ -197,6 +198,7 @@ export default async function BlogPostPage({ params }: Props) {
 
             <AuthorBio />
             <ShareButtons slug={post.slug} title={post.title} />
+            <SubscribeCTA className="mt-12" />
             <PostNavigation prev={prev} next={next} />
             <RelatedPosts posts={related} />
             <GiscusComments />

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,6 +1,7 @@
 import {
   ConnectSection,
   HeroSection,
+  NewsletterSection,
   ProjectsSection,
   TalksSection,
   WhatIDoSection,
@@ -28,6 +29,7 @@ export default function HomePage() {
       <WritingSection />
       <TalksSection />
       <ProjectsSection />
+      <NewsletterSection />
       <ConnectSection />
     </>
   );

--- a/src/app/(site)/sharing/page.tsx
+++ b/src/app/(site)/sharing/page.tsx
@@ -7,6 +7,7 @@ import { JsonLd } from "../../../components/ui/JsonLd";
 import { PageHero } from "../../../components/ui/PageHero";
 import { ScrollReveal } from "../../../components/ui/ScrollReveal";
 import { SectionHeader } from "../../../components/ui/SectionHeader";
+import { SubscribeCTA } from "../../../components/ui/SubscribeCTA";
 import { getAllTalks } from "../../../lib/content";
 
 export const metadata: Metadata = {
@@ -268,6 +269,16 @@ export default function SharingPage() {
               Get in touch →
             </a>
           </p>
+        </div>
+      </ScrollReveal>
+
+      {/* Newsletter CTA: framed around upcoming talks */}
+      <ScrollReveal>
+        <div className="mt-10">
+          <SubscribeCTA
+            heading="Catch my next talk"
+            description="Get my upcoming talks and workshops in your inbox, plus what I publish, once a month. No spam, unsubscribe anytime."
+          />
         </div>
       </ScrollReveal>
     </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,6 +3,7 @@ import { SOCIAL_PROFILES } from "../../lib/social";
 
 const FOOTER_LINKS = [
   { label: "contact", href: "/contact" },
+  { label: "newsletter", href: "/newsletter" },
   { label: "privacy", href: "/privacy" },
   { label: "now", href: "/now" },
   { label: "uses", href: "/uses" },

--- a/src/components/sections/NewsletterSection.tsx
+++ b/src/components/sections/NewsletterSection.tsx
@@ -1,0 +1,16 @@
+import { ScrollReveal } from "../ui/ScrollReveal";
+import { SubscribeCTA } from "../ui/SubscribeCTA";
+
+export function NewsletterSection() {
+  return (
+    <section className="border-t border-border py-20">
+      <div className="max-w-[1024px] mx-auto px-4 sm:px-8">
+        <ScrollReveal>
+          <div className="max-w-[520px] mx-auto">
+            <SubscribeCTA />
+          </div>
+        </ScrollReveal>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,6 +1,7 @@
 export { ConnectSection } from "./ConnectSection";
 export { HeroSection } from "./HeroSection";
 export { InteractiveTerminal } from "./InteractiveTerminal";
+export { NewsletterSection } from "./NewsletterSection";
 export { ProjectsSection } from "./ProjectsSection";
 export { TalksSection } from "./TalksSection";
 export { WhatIDoSection } from "./WhatIDoSection";

--- a/src/components/ui/SubscribeCTA.tsx
+++ b/src/components/ui/SubscribeCTA.tsx
@@ -1,0 +1,31 @@
+import { SubscribeForm } from "./SubscribeForm";
+
+interface SubscribeCTAProps {
+  heading?: string;
+  description?: string;
+  className?: string;
+}
+
+/**
+ * A compact, self-contained subscribe call-to-action: a short pitch above the compact
+ * SubscribeForm, in a bordered card. Reused at the end of blog posts, on the Sharing
+ * page (talks-framed copy), and inside the home NewsletterSection. The footer uses a
+ * plain text link instead, to keep the site's sober tone.
+ */
+export function SubscribeCTA({
+  heading = "Subscribe to the newsletter",
+  description = "One email a month: new posts, upcoming talks, and the occasional project. No spam, unsubscribe anytime.",
+  className = "",
+}: SubscribeCTAProps) {
+  return (
+    <div className={`border border-border rounded-sm bg-bg-card px-6 py-6 ${className}`}>
+      <h3 className="font-mono text-[14px] text-text-1 mb-1.5">{heading}</h3>
+      <p className="font-sans text-[13px] text-text-3 leading-relaxed mb-4 max-w-md">
+        {description}
+      </p>
+      <div className="max-w-md">
+        <SubscribeForm mode="compact" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -18,4 +18,5 @@ export { RelatedPosts } from "./RelatedPosts";
 export { ScrollReveal } from "./ScrollReveal";
 export { SectionHeader } from "./SectionHeader";
 export { ShareButtons } from "./ShareButtons";
+export { SubscribeCTA } from "./SubscribeCTA";
 export { TableOfContents } from "./TableOfContents";

--- a/src/stories/SubscribeCTA.stories.tsx
+++ b/src/stories/SubscribeCTA.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SubscribeCTA } from "../components/ui/SubscribeCTA";
+
+const meta: Meta<typeof SubscribeCTA> = {
+  title: "UI/SubscribeCTA",
+  component: SubscribeCTA,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#080807" }],
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SubscribeCTA>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="w-[520px] max-w-full">
+      <SubscribeCTA {...args} />
+    </div>
+  ),
+};
+
+export const TalksFramed: Story = {
+  args: {
+    heading: "Catch my next talk",
+    description:
+      "Get my upcoming talks and workshops in your inbox, plus what I publish, once a month. No spam, unsubscribe anytime.",
+  },
+  render: (args) => (
+    <div className="w-[520px] max-w-full">
+      <SubscribeCTA {...args} />
+    </div>
+  ),
+};


### PR DESCRIPTION
Closes #76. Wires the subscribe capability into the site's surfaces. Builds on #74 (SubscribeForm) and #72 (the `/newsletter` page), both merged.

## What's in it

- **`ui/SubscribeCTA.tsx`** — reusable card: a short pitch above the compact `SubscribeForm`. One component, three placements (blog-end, Sharing, home). Storybook story (default + talks-framed).
- **`sections/NewsletterSection.tsx`** — centered home section shell around `SubscribeCTA`, mirroring `ConnectSection`.
- **Home** — `NewsletterSection` added between Projects and Connect.
- **Sharing** — a talks-framed `SubscribeCTA` ("Catch my next talk", copy about upcoming talks) after the speak-at-your-event CTA.
- **Blog `[slug]`** — a compact `SubscribeCTA` after `AuthorBio`/`ShareButtons` in the post feature stack (before `PostNavigation`).
- **Footer** — a plain-text `newsletter` link (no box), consistent with the site's sober tone.

## Acceptance criteria

- [x] Full form on `/newsletter` (pre-existing from #72); compact form at the end of blog posts.
- [x] Compact CTAs on Home and Sharing; Sharing framed around upcoming talks.
- [x] Footer plain-text `/newsletter` link, no box.
- [x] `compact` mode has a Storybook story (from #74, intact); all placements responsive.

## Validation

`tsc --noEmit` clean · Biome clean · 177 tests pass · production build renders all 54 pages. Two-axis code review run; minor findings applied (comment em dash, story copy aligned to the live Sharing copy).

## Project status

This completes the user-facing newsletter surface. Remaining: **#73** (harvest engine) and **#77** (monthly digest drafting skill) — both author-side tooling, no more UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)