### PR TITLE
Home: terminal-band newsletter after Writing + trim footer

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -27,9 +27,9 @@ export default function HomePage() {
       <HeroSection />
       <WhatIDoSection />
       <WritingSection />
+      <NewsletterSection />
       <TalksSection />
       <ProjectsSection />
-      <NewsletterSection />
       <ConnectSection />
     </>
   );

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,6 @@ import { IconBrandBluesky, IconBrandGithub, IconBrandLinkedin } from "@tabler/ic
 import { SOCIAL_PROFILES } from "../../lib/social";
 
 const FOOTER_LINKS = [
-  { label: "contact", href: "/contact" },
   { label: "newsletter", href: "/newsletter" },
   { label: "privacy", href: "/privacy" },
   { label: "now", href: "/now" },

--- a/src/components/sections/NewsletterSection.tsx
+++ b/src/components/sections/NewsletterSection.tsx
@@ -1,13 +1,32 @@
 import { ScrollReveal } from "../ui/ScrollReveal";
-import { SubscribeCTA } from "../ui/SubscribeCTA";
+import { SubscribeForm } from "../ui/SubscribeForm";
 
+// A full-width band that speaks the site's terminal language: the "❯ subscribe --monthly"
+// prompt echoes the per-page command heroes, tying the newsletter to the site's core motif.
+// Left-aligned so it reads distinctly from the centered ConnectSection that closes the page.
 export function NewsletterSection() {
   return (
     <section className="border-t border-border py-20">
       <div className="max-w-[1024px] mx-auto px-4 sm:px-8">
         <ScrollReveal>
-          <div className="max-w-[520px] mx-auto">
-            <SubscribeCTA />
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_360px] gap-8 md:gap-12 md:items-center">
+            {/* Pitch */}
+            <div>
+              <h2 className="font-mono text-[11px] font-medium text-text-3 tracking-[0.12em] uppercase mb-4">
+                <span className="text-accent mr-2">{"//"}</span>newsletter
+              </h2>
+              <p className="font-mono text-[20px] sm:text-[24px] text-text-1 tracking-[-0.02em] mb-3">
+                <span className="text-accent mr-2">❯</span>subscribe --monthly
+              </p>
+              <p className="font-sans text-[14px] text-text-2 leading-relaxed max-w-md">
+                A short digest of what I published: new posts, upcoming talks, and the occasional
+                project. One email a month, no spam.
+              </p>
+            </div>
+            {/* Form */}
+            <div>
+              <SubscribeForm mode="compact" />
+            </div>
           </div>
         </ScrollReveal>
       </div>


### PR DESCRIPTION
Two small design refinements to the newsletter placements from #76 (they were committed just after #81 was squash-merged, so they missed that merge).

## Home newsletter block

The subscribe block read as disconnected: a narrow (520px) bordered card floating in the full-width home flow, sitting right before the (also-CTA) `ConnectSection`. Reworked `NewsletterSection` into a **full-width, left-aligned terminal band** that speaks the site's core motif (`❯ subscribe --monthly`, echoing the per-page command heroes) — pitch on the left, compact form on the right. Moved it to **right after Latest Writing** so it reads as a content beat ("read the posts, get them monthly"), leaving `ConnectSection` as the page's single closing CTA.

## Footer

Dropped the `contact` link — it is already in the top `NavBar`, so with the newsletter link added the footer had grown to 9 items. Now 8, no page lost.

## Validation

`tsc --noEmit` clean · Biome clean · production build renders all 54 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)