### PR TITLE
Newsletter: harvest engine (harvestWindow) (#73)

### DIFF
--- a/src/lib/harvest.test.ts
+++ b/src/lib/harvest.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { BlogPost, Project, Talk } from "./content";
+import { harvestWindow } from "./harvest";
+
+// Minimal fixtures: harvestWindow only reads post.date, talk.date, and project
+// featured/status, so we build just-valid objects rather than full content.
+function post(slug: string, date: string): BlogPost {
+  return {
+    slug,
+    title: slug,
+    excerpt: "",
+    category: "Technical",
+    tags: [],
+    date,
+    readingTime: "1 min read",
+    content: "",
+  };
+}
+
+function talk(slug: string, date: string): Talk {
+  return { slug, event: slug, type: "Conference", date, location: "", tags: [] };
+}
+
+function project(slug: string, featured: boolean, status: Project["status"]): Project {
+  return { slug, title: slug, status, period: "", featured, tags: [], description: "" };
+}
+
+const WINDOW = { from: "2026-07-01", to: "2026-07-31" };
+
+describe("harvestWindow - posts", () => {
+  it("selects only posts published within the window, inclusive of both edges", () => {
+    const posts = [
+      post("before", "2026-06-30"),
+      post("on-from", "2026-07-01"),
+      post("mid", "2026-07-15"),
+      post("on-to", "2026-07-31"),
+      post("after", "2026-08-01"),
+    ];
+    const { posts: got } = harvestWindow({ ...WINDOW, posts, talks: [] });
+    expect(got.map((p) => p.slug)).toEqual(["on-to", "mid", "on-from"]);
+  });
+
+  it("orders selected posts newest-first", () => {
+    const posts = [post("a", "2026-07-05"), post("b", "2026-07-20"), post("c", "2026-07-10")];
+    const { posts: got } = harvestWindow({ ...WINDOW, posts, talks: [] });
+    expect(got.map((p) => p.slug)).toEqual(["b", "c", "a"]);
+  });
+});
+
+describe("harvestWindow - upcoming talks", () => {
+  it("selects only talks after the window end, soonest-first", () => {
+    const talks = [
+      talk("past", "2026-05-10"), // before window
+      talk("in-window", "2026-07-15"), // inside the reported month, already happened by send
+      talk("on-to", "2026-07-31"), // exactly the send date - not upcoming
+      talk("soon", "2026-08-10"),
+      talk("later", "2026-09-02"),
+    ];
+    const { upcomingTalks } = harvestWindow({ ...WINDOW, posts: [], talks });
+    expect(upcomingTalks.map((t) => t.slug)).toEqual(["soon", "later"]);
+  });
+});
+
+describe("harvestWindow - projects (optional passthrough)", () => {
+  it("returns only featured active projects, and is empty when none provided", () => {
+    expect(harvestWindow({ ...WINDOW, posts: [], talks: [] }).projects).toEqual([]);
+
+    const projects = [
+      project("featured-active", true, "active"),
+      project("featured-archived", true, "archived"),
+      project("plain-active", false, "active"),
+    ];
+    const { projects: got } = harvestWindow({ ...WINDOW, posts: [], talks: [], projects });
+    expect(got.map((p) => p.slug)).toEqual(["featured-active"]);
+  });
+});
+
+describe("harvestWindow - skippable (empty month)", () => {
+  it("is skippable when there are no posts and no upcoming talks", () => {
+    expect(harvestWindow({ ...WINDOW, posts: [], talks: [] }).skippable).toBe(true);
+  });
+
+  it("is not skippable when there is a post in the window", () => {
+    const result = harvestWindow({ ...WINDOW, posts: [post("p", "2026-07-10")], talks: [] });
+    expect(result.skippable).toBe(false);
+  });
+
+  it("is not skippable when there is an upcoming talk", () => {
+    const result = harvestWindow({ ...WINDOW, posts: [], talks: [talk("t", "2026-08-10")] });
+    expect(result.skippable).toBe(false);
+  });
+
+  it("ignores projects for the skippable decision", () => {
+    const result = harvestWindow({
+      ...WINDOW,
+      posts: [],
+      talks: [],
+      projects: [project("p", true, "active")],
+    });
+    expect(result.skippable).toBe(true);
+  });
+});

--- a/src/lib/harvest.ts
+++ b/src/lib/harvest.ts
@@ -1,0 +1,64 @@
+import type { BlogPost, Project, Talk } from "./content";
+
+// Pure engine behind the monthly digest. Given a window and the content, it returns the
+// structured raw material for an issue: posts published in the window, forward-looking
+// talks, optional highlighted projects, and whether the month is empty enough to skip.
+// No I/O: content is passed in, so windowing/selection is deterministic and fixture-testable
+// (the drafting skill wires the real content loaders to it).
+
+export interface HarvestInput {
+  /** ISO date, inclusive lower bound of the reported window. */
+  from: string;
+  /** ISO date, inclusive upper bound (the send date / end of month). */
+  to: string;
+  posts: BlogPost[];
+  talks: Talk[];
+  projects?: Project[];
+}
+
+export interface HarvestResult {
+  /** Posts published within [from, to], newest first. */
+  posts: BlogPost[];
+  /** Talks scheduled after the window end, soonest first ("where to catch me next"). */
+  upcomingTalks: Talk[];
+  /**
+   * Featured active projects, passed through as an optional highlight. Projects carry no
+   * publish date (only a free-text `period`), so they are NOT date-windowed.
+   */
+  projects: Project[];
+  /** True when there are no posts AND no upcoming talks - nothing worth sending. */
+  skippable: boolean;
+}
+
+const time = (iso: string): number => new Date(iso).getTime();
+
+export function harvestWindow({
+  from,
+  to,
+  posts,
+  talks,
+  projects = [],
+}: HarvestInput): HarvestResult {
+  const fromT = time(from);
+  const toT = time(to);
+
+  const windowPosts = posts
+    .filter((p) => {
+      const t = time(p.date);
+      return t >= fromT && t <= toT;
+    })
+    .sort((a, b) => time(b.date) - time(a.date));
+
+  const upcomingTalks = talks
+    .filter((t) => time(t.date) > toT)
+    .sort((a, b) => time(a.date) - time(b.date));
+
+  const highlightedProjects = projects.filter((p) => p.featured && p.status === "active");
+
+  return {
+    posts: windowPosts,
+    upcomingTalks,
+    projects: highlightedProjects,
+    skippable: windowPosts.length === 0 && upcomingTalks.length === 0,
+  };
+}


### PR DESCRIPTION
Closes #73. The pure engine behind the monthly digest.

## What's in it

`src/lib/harvest.ts` — `harvestWindow({ from, to, posts, talks, projects? })`, I/O-free (content passed in, so it is deterministic and fixture-testable; the drafting skill #77 wires the real loaders):

- **posts**: published within `[from, to]` inclusive, newest-first.
- **upcomingTalks**: scheduled after the window end `to`, soonest-first ("where to catch me next").
- **projects**: featured active projects, passed through as an optional highlight. Projects carry no publish date (only a free-text `period`), so they are deliberately **not** date-windowed (documented in the JSDoc).
- **skippable**: `true` when there are no posts AND no upcoming talks (the empty-month rule), ignoring projects.

## Acceptance criteria

- [x] Given fixtures + a window, returns exactly the items inside the window, correctly ordered.
- [x] Window edges handled explicitly (inclusive `[from, to]`) and covered by tests (posts on `from` and `to` included; just-outside excluded).
- [x] Upcoming talks selected relative to the window (after `to`, exclusive of the send date) — boundary tested.
- [x] Empty month reported as skippable (and skippable ignores projects).
- [x] Fixture-only tests, no mocks — matches the `terminal.test.ts` / `content.test.ts` pure-engine style.

## Validation

`tsc --noEmit` clean · Biome clean · 185 tests pass (8 new). Two-axis code review run; findings were all defensible judgement calls (documented), no changes required.

## Next

The last piece is **#77** — the monthly digest drafting skill that orchestrates `harvestWindow` + the content-os MCP, writes the frozen `.mdx`, and (via #75) renders the email + creates the Kit broadcast draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)