### PR TITLE
Newsletter issue #1: I shipped one tool, abandoned another, back on stage

### DIFF
--- a/src/content/newsletter/2026-07.mdx
+++ b/src/content/newsletter/2026-07.mdx
@@ -1,0 +1,73 @@
+---
+issue: 1
+subject: "Issue #1: I shipped one tool, abandoned another, back on stage"
+previewText: "Argus goes open source, Worky stays an experiment, and three conferences said yes after a year off stage."
+sendDate: "2026-08-05"
+---
+
+This is the first issue, so here is what it is: once a month I write up what actually happened. What I found, what I tried, what I built, what I killed. A monthly statement of account on my work and on the things I am making, not a list of links I liked.
+
+July was a month where a few things genuinely changed direction, and you can see it in the two posts below. They point opposite ways, and that is the point.
+
+<SectionHeader title="New on the blog" />
+
+First I had to admit I was building a tool I was not using. That was hard to see and harder to write down, because Worky was not the thing I actually wanted to be working on. So I stopped: not because it failed, but because I had no intention of carrying it forward, and pretending otherwise would have been the incoherent move.
+
+<PostCard
+  title="I Built a Tool I Don't Use"
+  url="/blog/i-built-a-tool-i-dont-use"
+  category="Technical"
+  description="Worky took a weekend to build and the workshop it was for never happened. On what AI made cheap, what it did not, and letting a project stay an experiment."
+  meta="Jul 8, 2026 · 9 min read"
+/>
+
+Then something else held my attention properly. Argus sits exactly where I think the interesting work is right now: security and AI, and specifically the overlap between the two. It is pre-1.0 and there is a lot left to do, but as a first pre-release I am happy with it, and I get to spend the next months making it more reliable and more useful to people other than me.
+
+<PostCard
+  title="Introducing Argus: The Code Security Colleague Your Team Doesn't Have"
+  url="/blog/introducing-argus"
+  category="Technical"
+  description="Most AI agents are a language model with a shell pointed at your repo. Argus is my bet on a different mix: real scanners as structured tools, a human in the loop, and a model reasoning across both."
+  meta="Jul 30, 2026 · 17 min read"
+/>
+
+<SectionHeader title="Where to catch me" />
+
+I also spent a full year off stage. That is over: three events said yes, and all three are about security and AI. The focus is deliberate. For a long time I talked about whatever I happened to be doing that year, and now there are two threads instead of ten, plus everything that happens where they meet. Giving the work a direction turned out to make it much easier to decide what to say yes to.
+
+<TalkRow
+  event="ComeToCode 2026"
+  date="Sep 26, 2026"
+  location="Pignola, Italy"
+  type="Conference"
+  sessionTitle="Il security engineer che già AI"
+  url="/sharing#cometocode-2026"
+/>
+
+<TalkRow
+  event="GoLab 2026"
+  date="Nov 1, 2026"
+  location="Bologna, Italy"
+  type="Conference"
+  sessionTitle="Securing Go for Production: Best Practices, Supply Chain, Testing"
+  url="/sharing#golab-2026"
+/>
+
+<TalkRow
+  event="reactjsday 2026"
+  date="Nov 19, 2026"
+  location="Verona, Italy"
+  type="Conference"
+  sessionTitle="AI Won't Design Your System. You Have To."
+  url="/sharing#reactjsday-2026"
+/>
+
+<SectionHeader title="One thing I'm still unsure about" />
+
+I do not have a take on this one, which is exactly why I am asking. How do you onboard a junior now that the AI is already in the room? I learned by walking into a codebase with nothing there to help me and figuring it out the hard way, and that route is basically gone. Maybe the order flips: first learn to read and understand the code that already exists, then write your own in small side projects. Honestly, I do not know.
+
+If you are onboarding juniors right now, hit reply and tell me what you are doing. I am collecting answers before I write anything about it.
+
+That is July. Later this month I am writing up the agent skills I actually use for security review, which is the practical follow-up to Argus.
+
+<Cta href="/newsletter" variant="primary">Browse the archive →</Cta>


### PR DESCRIPTION
First newsletter issue (ADR-0002), covering July 2026: the two blog posts published in the window, the three upcoming conferences, and a new recurring "One thing I'm still unsure about" block that asks a real open question and invites replies.

Harvested with `harvestWindow` over `2026-07-01` → `2026-07-31`. Kit broadcast draft created (id=25307040, never sent). No newsletter Piece exists on the content-os Pipeline for this issue, so this `.mdx` plus the Kit draft are the deliverable.